### PR TITLE
remove keys from envs due to mistake when re setup the project

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,12 +1,12 @@
 PORT=5000
-MONGO_URI=mongodb+srv://chouaib41skitou:K3IctmCzV6hCi671@clusterrestapi.uaxra.mongodb.net/?retryWrites=true&w=majority&appName=ClusterRestApi
-JWT_SECRET=97bdd1004e8ce6d3b37519bd488cd3722f3bbcc5c1f01491ac0103233a6e5c91e18ebd3231add7577211f672edc20c109698996fb9046608ea95fed108695f21
-JWT_REFRESH_SECRET=f098d28149883f7332d383b97f52941645212251f0d36fcb4592d1ba76a7f2cf8652122d0b03e42f3d7dfe693ed7efd6418e73e5ae14f46036ee6066f2397ae9
+MONGO_URI=
+JWT_SECRET=
+JWT_REFRESH_SECRET=
 
-EMAIL_USER=festivio.polytech.pops@gmail.com
-EMAIL_PASS=sypamqjnhhsxotxo
+EMAIL_USER=
+EMAIL_PASS=
 
-FRONTEND_URL=http://localhost:3000/
-BACKEND_URL=http://localhost:5000/
+FRONTEND_URL=https://festivio-h5wv.vercel.app/
+BACKEND_URL=https://festivio-nine.vercel.app/
 ENV=production
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-REACT_APP_BACKEND_URL=http://localhost:5000/
+REACT_APP_BACKEND_URL=https://festivio-h5wv.vercel.app/


### PR DESCRIPTION
remove keys from envs due to mistake when re setup the project and add prod links 

/backend/.env
PORT=5000
MONGO_URI=
JWT_SECRET=
JWT_REFRESH_SECRET=

EMAIL_USER=
EMAIL_PASS=

FRONTEND_URL=https://festivio-h5wv.vercel.app/
BACKEND_URL=https://festivio-nine.vercel.app/
ENV=production

/frontend/.env
REACT_APP_BACKEND_URL=https://festivio-h5wv.vercel.app/


