### PR TITLE
feat: redesign public website and workspace experience

### DIFF
--- a/frontend/src/components/NavBar/Brand.js
+++ b/frontend/src/components/NavBar/Brand.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { CalendarDays } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+const Brand = ({ to = '/', compact = false, onClick }) => (
+  <Link to={to} className={`brand ${compact ? 'brand-compact' : ''}`} onClick={onClick} aria-label="Festivio home">
+    <span className="brand-mark" aria-hidden="true"><CalendarDays size={18} /></span>
+    <span className="brand-wordmark">Festivio</span>
+  </Link>
+);
+
+export default Brand;

--- a/frontend/src/components/NavBar/MarketingNav.js
+++ b/frontend/src/components/NavBar/MarketingNav.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { ArrowRight, Menu, X } from 'lucide-react';
+import { Link, useLocation } from 'react-router-dom';
+import useAuthStore from '../../stores/authStore';
+import Brand from './Brand';
+
+const MarketingNav = ({ open, setOpen }) => {
+  const location = useLocation();
+  const accessToken = useAuthStore((state) => state.accessToken);
+  const close = () => setOpen(false);
+  const active = (path) => (location.pathname === path ? 'active' : '');
+
+  return (
+    <header className="site-header marketing-header">
+      <nav className="navbar marketing-navbar" aria-label="Website navigation">
+        <Brand onClick={close} />
+
+        <button className="menu-toggle" onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-label="Toggle website navigation">
+          {open ? <X size={20} /> : <Menu size={20} />}
+        </button>
+
+        <div className={`navbar-links marketing-links ${open ? 'open' : ''}`}>
+          <a href="/#features" onClick={close}>Features</a>
+          <a href="/#workflow" onClick={close}>How it works</a>
+          <Link to="/services" className={active('/services')} onClick={close}>Platform</Link>
+          {accessToken ? (
+            <Link to="/home" className="nav-cta" onClick={close}>Open workspace <ArrowRight size={16} /></Link>
+          ) : (
+            <>
+              <Link to="/login" className={active('/login')} onClick={close}>Sign in</Link>
+              <Link to="/register" className="nav-cta" onClick={close}>Get started <ArrowRight size={16} /></Link>
+            </>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+};
+
+export default MarketingNav;

--- a/frontend/src/components/NavBar/NavBar.js
+++ b/frontend/src/components/NavBar/NavBar.js
@@ -1,71 +1,21 @@
-import React, { useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { CalendarDays, Menu, X } from 'lucide-react';
-import axiosInstance from '../../api/axiosInstance';
-import useAuthStore from '../../stores/authStore';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import MarketingNav from './MarketingNav';
+import WorkspaceNav from './WorkspaceNav';
 import './NavBar.scss';
+
+const workspacePrefixes = ['/home', '/events', '/tasks', '/profile'];
 
 const NavBar = () => {
   const [open, setOpen] = useState(false);
   const location = useLocation();
-  const navigate = useNavigate();
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const user = useAuthStore((state) => state.user);
-  const clearSession = useAuthStore((state) => state.clearSession);
+  const isWorkspace = workspacePrefixes.some((path) => location.pathname === path || location.pathname.startsWith(`${path}/`));
 
-  const close = () => setOpen(false);
-  const active = (path) => (location.pathname === path ? 'active' : '');
+  useEffect(() => {
+    setOpen(false);
+  }, [location.pathname]);
 
-  const handleLogout = async () => {
-    try {
-      await axiosInstance.post('/api/auth/logout', undefined, { _skipAuthRefresh: true });
-    } finally {
-      clearSession();
-      close();
-      navigate('/', { replace: true });
-    }
-  };
-
-  const workspaceLinks = [];
-  if (['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN', 'ROLE_PARTICIPANT'].includes(user?.role)) {
-    workspaceLinks.push({ to: '/events', label: 'Events' });
-  }
-  if (['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN', 'ROLE_ORGANIZER'].includes(user?.role)) {
-    workspaceLinks.push({ to: '/tasks', label: 'Tasks' });
-  }
-
-  return (
-    <header className="site-header">
-      <nav className="navbar" aria-label="Main navigation">
-        <Link to="/" className="brand" onClick={close}>
-          <span className="brand-mark"><CalendarDays size={19} /></span>
-          <span>Festivio</span>
-        </Link>
-
-        <button className="menu-toggle" onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-label="Toggle navigation">
-          {open ? <X /> : <Menu />}
-        </button>
-
-        <div className={`navbar-links ${open ? 'open' : ''}`}>
-          <Link to="/" className={active('/')} onClick={close}>Home</Link>
-          <Link to="/services" className={active('/services')} onClick={close}>Platform</Link>
-          {accessToken ? (
-            <>
-              <Link to="/home" className={active('/home')} onClick={close}>Workspace</Link>
-              {workspaceLinks.map((link) => <Link key={link.to} to={link.to} className={active(link.to)} onClick={close}>{link.label}</Link>)}
-              <Link to="/profile" className={active('/profile')} onClick={close}>Profile</Link>
-              <button className="nav-quiet-button" onClick={handleLogout}>Sign out</button>
-            </>
-          ) : (
-            <>
-              <Link to="/login" className={active('/login')} onClick={close}>Sign in</Link>
-              <Link to="/register" className="nav-cta" onClick={close}>Get started</Link>
-            </>
-          )}
-        </div>
-      </nav>
-    </header>
-  );
+  return isWorkspace ? <WorkspaceNav open={open} setOpen={setOpen} /> : <MarketingNav open={open} setOpen={setOpen} />;
 };
 
 export default NavBar;

--- a/frontend/src/components/NavBar/NavBar.scss
+++ b/frontend/src/components/NavBar/NavBar.scss
@@ -2,104 +2,146 @@
   position: fixed;
   inset: 0 0 auto;
   z-index: 100;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
-  background: rgba(7, 12, 24, 0.88);
-  backdrop-filter: blur(18px);
+  padding: 14px 20px 0;
+  pointer-events: none;
 }
 
 .navbar {
-  max-width: 1180px;
-  height: 72px;
+  width: min(var(--container), calc(100vw - 32px));
+  min-height: 58px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 8px 10px 8px 12px;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 18px;
+  border: 1px solid transparent;
+  border-radius: 18px;
+  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
+  pointer-events: auto;
+  transition: background var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.marketing-navbar {
+  color: var(--marketing-text);
+  background: rgba(248, 248, 246, 0.78);
+  border-color: rgba(17, 19, 23, 0.08);
+  box-shadow: 0 12px 32px rgba(16, 24, 40, 0.07);
+}
+
+.workspace-navbar {
+  color: var(--app-text);
+  background: rgba(10, 14, 21, 0.8);
+  border-color: var(--app-border);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
 }
 
 .brand {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  color: #f8fafc;
-  font-size: 1.08rem;
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  min-width: max-content;
+  color: inherit;
   text-decoration: none;
+  font-weight: 800;
+  letter-spacing: -0.025em;
 }
 
 .brand-mark {
+  width: 34px;
+  height: 34px;
   display: grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  color: white;
-  background: linear-gradient(135deg, #7c3aed, #2563eb);
-  box-shadow: 0 8px 28px rgba(79, 70, 229, 0.35);
+  border-radius: 11px;
+  color: #fff;
+  background: linear-gradient(145deg, var(--brand-500), #3b82f6);
+  box-shadow: 0 8px 24px rgba(91, 92, 240, 0.28);
 }
+
+.brand-wordmark { font-size: 1rem; }
+.brand-compact .brand-mark { width: 32px; height: 32px; }
+
+.workspace-brand-group { display: flex; align-items: center; gap: 12px; }
+.workspace-divider { width: 1px; height: 22px; background: rgba(255,255,255,.12); }
+.workspace-label { color: var(--app-muted); font-size: .78rem; font-weight: 700; letter-spacing: .02em; }
 
 .navbar-links {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
 
 .navbar-links a,
 .nav-quiet-button {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 12px;
   border: 0;
-  background: transparent;
-  color: #a7b0c0;
-  padding: 9px 12px;
   border-radius: 10px;
-  font: inherit;
-  font-size: 0.9rem;
-  font-weight: 650;
+  background: transparent;
+  color: inherit;
   text-decoration: none;
-  cursor: pointer;
+  font-size: .82rem;
+  font-weight: 650;
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
 }
 
-.navbar-links a:hover,
-.navbar-links a.active,
-.nav-quiet-button:hover {
-  color: white;
-  background: rgba(255, 255, 255, 0.06);
-}
+.marketing-links a:not(.nav-cta) { color: #4b5563; }
+.marketing-links a:not(.nav-cta):hover,
+.marketing-links a.active { color: #111317; background: rgba(17, 19, 23, 0.05); }
+
+.workspace-links a,
+.workspace-links .nav-quiet-button { color: #aab3c2; }
+.workspace-links a:hover,
+.workspace-links a.active,
+.workspace-links .nav-quiet-button:hover { color: #fff; background: rgba(255,255,255,.06); }
 
 .navbar-links .nav-cta {
-  margin-left: 5px;
-  color: white;
-  background: linear-gradient(135deg, #7c3aed, #2563eb);
+  margin-left: 4px;
+  padding-inline: 15px;
+  color: #fff;
+  background: #111317;
+  box-shadow: 0 8px 20px rgba(17, 19, 23, 0.16);
 }
 
-.navbar-links .nav-cta:hover { background: linear-gradient(135deg, #8b5cf6, #3b82f6); }
+.navbar-links .nav-cta:hover { transform: translateY(-1px); background: #000; }
+.workspace-links .back-to-site { margin-right: 5px; color: #c7cce0; background: rgba(255,255,255,.04); }
 
 .menu-toggle {
   display: none;
+  width: 38px;
+  height: 38px;
+  place-items: center;
   border: 0;
+  border-radius: 11px;
   background: transparent;
-  color: white;
-  padding: 8px;
-  cursor: pointer;
+  color: inherit;
 }
 
-@media (max-width: 860px) {
-  .menu-toggle { display: grid; place-items: center; }
+@media (max-width: 820px) {
+  .site-header { padding: 10px 10px 0; }
+  .navbar { width: 100%; min-height: 56px; position: relative; }
+  .menu-toggle { display: grid; }
+  .workspace-label, .workspace-divider { display: none; }
   .navbar-links {
-    display: none;
     position: absolute;
-    top: 72px;
-    left: 16px;
-    right: 16px;
-    padding: 14px;
-    flex-direction: column;
-    align-items: stretch;
-    border: 1px solid rgba(148, 163, 184, 0.18);
-    border-radius: 18px;
-    background: #0b1120;
-    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.38);
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    display: none;
+    padding: 10px;
+    border: 1px solid transparent;
+    border-radius: 16px;
+    box-shadow: var(--shadow-md);
+    backdrop-filter: blur(var(--glass-blur)) saturate(160%);
   }
-  .navbar-links.open { display: flex; }
-  .navbar-links a, .nav-quiet-button { text-align: left; width: 100%; }
-  .navbar-links .nav-cta { margin-left: 0; text-align: center; }
+  .marketing-links { background: rgba(248,248,246,.96); border-color: rgba(17,19,23,.08); }
+  .workspace-links { background: rgba(10,14,21,.96); border-color: var(--app-border); }
+  .navbar-links.open { display: grid; }
+  .navbar-links a, .nav-quiet-button { width: 100%; justify-content: flex-start; min-height: 44px; }
+  .navbar-links .nav-cta { margin: 4px 0 0; justify-content: center; }
 }

--- a/frontend/src/components/NavBar/NavBar.test.js
+++ b/frontend/src/components/NavBar/NavBar.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import useAuthStore from '../../stores/authStore';
+import NavBar from './NavBar';
+
+const renderAt = (path) => render(
+  <MemoryRouter initialEntries={[path]}>
+    <NavBar />
+  </MemoryRouter>
+);
+
+afterEach(() => {
+  useAuthStore.setState({ accessToken: null, user: null });
+});
+
+test('renders website navigation on public routes', () => {
+  renderAt('/');
+
+  expect(screen.getByRole('navigation', { name: /website navigation/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login');
+  expect(screen.getByRole('link', { name: /get started/i })).toHaveAttribute('href', '/register');
+});
+
+test('offers the workspace from the website when authenticated', () => {
+  useAuthStore.setState({ accessToken: 'test-token', user: { role: 'ROLE_PARTICIPANT' } });
+  renderAt('/');
+
+  expect(screen.getByRole('link', { name: /open workspace/i })).toHaveAttribute('href', '/home');
+});
+
+test('renders focused workspace navigation on application routes', () => {
+  useAuthStore.setState({ accessToken: 'test-token', user: { role: 'ROLE_ORGANIZER_ADMIN' } });
+  renderAt('/home');
+
+  expect(screen.getByRole('navigation', { name: /workspace navigation/i })).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /website/i })).toHaveAttribute('href', '/');
+  expect(screen.getByRole('link', { name: /overview/i })).toHaveAttribute('href', '/home');
+  expect(screen.getByRole('link', { name: /events/i })).toHaveAttribute('href', '/events');
+  expect(screen.getByRole('link', { name: /tasks/i })).toHaveAttribute('href', '/tasks');
+});

--- a/frontend/src/components/NavBar/WorkspaceNav.js
+++ b/frontend/src/components/NavBar/WorkspaceNav.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ArrowLeft, LogOut, Menu, X } from 'lucide-react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import axiosInstance from '../../api/axiosInstance';
+import useAuthStore from '../../stores/authStore';
+import Brand from './Brand';
+
+const WorkspaceNav = ({ open, setOpen }) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
+  const clearSession = useAuthStore((state) => state.clearSession);
+  const close = () => setOpen(false);
+  const active = (path) => (location.pathname === path || location.pathname.startsWith(`${path}/`) ? 'active' : '');
+
+  const links = [{ to: '/home', label: 'Overview' }];
+  if (['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN', 'ROLE_PARTICIPANT'].includes(user?.role)) links.push({ to: '/events', label: 'Events' });
+  if (['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN', 'ROLE_ORGANIZER'].includes(user?.role)) links.push({ to: '/tasks', label: 'Tasks' });
+  links.push({ to: '/profile', label: 'Profile' });
+
+  const handleLogout = async () => {
+    try {
+      await axiosInstance.post('/api/auth/logout', undefined, { _skipAuthRefresh: true });
+    } finally {
+      clearSession();
+      close();
+      navigate('/', { replace: true });
+    }
+  };
+
+  return (
+    <header className="site-header workspace-header">
+      <nav className="navbar workspace-navbar" aria-label="Workspace navigation">
+        <div className="workspace-brand-group">
+          <Brand to="/home" compact onClick={close} />
+          <span className="workspace-divider" aria-hidden="true" />
+          <span className="workspace-label">Workspace</span>
+        </div>
+
+        <button className="menu-toggle" onClick={() => setOpen((value) => !value)} aria-expanded={open} aria-label="Toggle workspace navigation">
+          {open ? <X size={20} /> : <Menu size={20} />}
+        </button>
+
+        <div className={`navbar-links workspace-links ${open ? 'open' : ''}`}>
+          <Link to="/" className="back-to-site" onClick={close}><ArrowLeft size={15} /> Website</Link>
+          {links.map((link) => <Link key={link.to} to={link.to} className={active(link.to)} onClick={close}>{link.label}</Link>)}
+          <button className="nav-quiet-button" onClick={handleLogout}><LogOut size={15} /> Sign out</button>
+        </div>
+      </nav>
+    </header>
+  );
+};
+
+export default WorkspaceNav;

--- a/frontend/src/features/Home/HomePage.js
+++ b/frontend/src/features/Home/HomePage.js
@@ -1,32 +1,66 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowRight, CalendarCheck, CheckCircle2, ListTodo, ShieldCheck, Sparkles, Users } from 'lucide-react';
+import {
+  ArrowRight,
+  CalendarCheck,
+  CheckCircle2,
+  ListTodo,
+  ShieldCheck,
+  Sparkles,
+  Users,
+} from 'lucide-react';
+import useAuthStore from '../../stores/authStore';
 import './HomePage.scss';
 
 const HomePage = () => {
+  const accessToken = useAuthStore((state) => state.accessToken);
+
   return (
     <main className="marketing-page">
       <section className="hero-section">
-        <div className="hero-glow hero-glow-one" />
-        <div className="hero-glow hero-glow-two" />
+        <div className="hero-aurora hero-aurora-one" />
+        <div className="hero-aurora hero-aurora-two" />
         <div className="marketing-container hero-layout">
           <div className="hero-copy">
-            <div className="hero-badge"><Sparkles size={15} /> Event operations, without the chaos</div>
-            <h1>Plan the event.<br /><span>Run the whole team.</span></h1>
-            <p>Festivio brings event creation, participant coordination and operational tasks into one focused workspace for organizers and communities.</p>
+            <div className="hero-badge"><Sparkles size={14} /> Calm operations for ambitious events</div>
+            <h1>Everything your event team needs. <span>Nothing it doesn’t.</span></h1>
+            <p className="hero-lead">Festivio brings event planning, team assignments and participant coordination into one focused workspace designed to stay clear when event day gets busy.</p>
             <div className="hero-actions">
-              <Link to="/register" className="primary-button large">Start with Festivio <ArrowRight size={18} /></Link>
-              <Link to="/services" className="secondary-button large">Explore the platform</Link>
+              <Link to={accessToken ? '/home' : '/register'} className="primary-button marketing-primary large">
+                {accessToken ? 'Open your workspace' : 'Start with Festivio'} <ArrowRight size={18} />
+              </Link>
+              <a href="#features" className="secondary-button marketing-secondary large">See what’s inside</a>
             </div>
-            <div className="hero-proof"><span><CheckCircle2 size={16} /> Role-based access</span><span><CheckCircle2 size={16} /> Secure sessions</span><span><CheckCircle2 size={16} /> One-command local stack</span></div>
+            <div className="hero-proof">
+              <span><CheckCircle2 size={15} /> Role-aware access</span>
+              <span><CheckCircle2 size={15} /> Secure sessions</span>
+              <span><CheckCircle2 size={15} /> Built for real operations</span>
+            </div>
           </div>
 
-          <div className="product-preview" aria-label="Festivio product preview">
-            <div className="preview-top"><span className="preview-logo">F</span><span>Community Week</span><span className="preview-status">Live workspace</span></div>
-            <div className="preview-grid">
-              <div className="preview-panel preview-event"><p className="preview-label">NEXT EVENT</p><h3>Opening Night</h3><p>Friday · 18:30</p><div className="preview-progress"><span /></div><small>Coordination ready</small></div>
-              <div className="preview-panel"><p className="preview-label">TEAM</p><div className="avatar-row"><span>MA</span><span>OL</span><span>PC</span><span>+8</span></div><p>Organizers and participants aligned in one workspace.</p></div>
-              <div className="preview-panel preview-tasks"><p className="preview-label">TASKS</p><div><CheckCircle2 size={16} /> Venue walkthrough <b>Done</b></div><div><ListTodo size={16} /> Check-in desk <b>In progress</b></div><div><ListTodo size={16} /> Speaker briefing <b>Pending</b></div></div>
+          <div className="product-preview" aria-label="Festivio workspace preview">
+            <div className="preview-window-bar">
+              <div className="preview-dots" aria-hidden="true"><span /><span /><span /></div>
+              <span>festivio / workspace</span>
+              <span className="preview-live">Live</span>
+            </div>
+            <div className="preview-body">
+              <aside className="preview-sidebar">
+                <div className="preview-mini-brand">F</div>
+                <span className="selected" />
+                <span />
+                <span />
+                <span />
+              </aside>
+              <div className="preview-content">
+                <div className="preview-heading"><div><small>GOOD MORNING</small><strong>Community Week</strong></div><button>+ New event</button></div>
+                <div className="preview-stats"><article><small>UPCOMING</small><strong>04</strong><span>events</span></article><article><small>OPEN TASKS</small><strong>12</strong><span>across the team</span></article><article><small>PARTICIPANTS</small><strong>248</strong><span>registered</span></article></div>
+                <div className="preview-grid">
+                  <article className="preview-panel preview-event"><p className="preview-label">NEXT EVENT</p><h3>Opening Night</h3><p>Friday · 18:30</p><div className="preview-progress"><span /></div><small>Coordination ready</small></article>
+                  <article className="preview-panel"><p className="preview-label">TEAM</p><div className="avatar-row"><span>MA</span><span>OL</span><span>PC</span><span>+8</span></div><p>Organizers and participants aligned in one workspace.</p></article>
+                  <article className="preview-panel preview-tasks"><p className="preview-label">TASKS</p><div><CheckCircle2 size={15} /> Venue walkthrough <b>Done</b></div><div><ListTodo size={15} /> Check-in desk <b>In progress</b></div><div><ListTodo size={15} /> Speaker briefing <b>Pending</b></div></article>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -34,35 +68,41 @@ const HomePage = () => {
 
       <section className="marketing-section" id="features">
         <div className="marketing-container">
-          <div className="section-heading"><p className="eyebrow">Built for execution</p><h2>Everything your event team needs to stay in sync.</h2><p>Clear responsibilities, shared event context and focused workflows from planning through participation.</p></div>
+          <div className="section-heading"><p className="eyebrow">One focused platform</p><h2>Designed around the work that actually happens.</h2><p>From the first event draft to the final task update, every role gets the context it needs without exposing controls it should not have.</p></div>
           <div className="feature-grid">
             <article><span className="feature-icon"><CalendarCheck /></span><h3>Event management</h3><p>Create and manage event details, attendance and online or in-person formats from one place.</p></article>
-            <article><span className="feature-icon"><ListTodo /></span><h3>Operational tasks</h3><p>Organizer administrators can assign work while organizers focus on the tasks they own.</p></article>
-            <article><span className="feature-icon"><Users /></span><h3>Participant flow</h3><p>Participants can discover events, join them and leave when plans change without operational access.</p></article>
-            <article><span className="feature-icon"><ShieldCheck /></span><h3>Role-aware security</h3><p>Administrative, organizer and participant permissions are enforced by the API—not just hidden in the UI.</p></article>
+            <article><span className="feature-icon"><ListTodo /></span><h3>Operational tasks</h3><p>Assign concrete work, track execution and keep ownership visible as plans move forward.</p></article>
+            <article><span className="feature-icon"><Users /></span><h3>Participant flow</h3><p>Let participants discover and join events without mixing attendee actions with organizer controls.</p></article>
+            <article><span className="feature-icon"><ShieldCheck /></span><h3>Security by role</h3><p>Permissions are enforced by the backend, with secure sessions and explicit role boundaries throughout the product.</p></article>
           </div>
         </div>
       </section>
 
-      <section className="marketing-section workflow-section">
+      <section className="marketing-section workflow-section" id="workflow">
         <div className="marketing-container workflow-layout">
-          <div className="section-heading left"><p className="eyebrow">A clean operating model</p><h2>From idea to event day in three clear steps.</h2></div>
+          <div className="section-heading left"><p className="eyebrow">A simple operating model</p><h2>Move from planning to execution without changing tools.</h2><p>Festivio keeps the operating loop intentionally small so teams can stay focused on delivery.</p></div>
           <div className="workflow-steps">
-            <article><span>01</span><div><h3>Create the event</h3><p>Set the essentials, choose the format and publish a shared source of truth.</p></div></article>
-            <article><span>02</span><div><h3>Coordinate the team</h3><p>Assign concrete tasks to organizers and track progress as execution moves forward.</p></div></article>
-            <article><span>03</span><div><h3>Bring participants in</h3><p>Let attendees join relevant events while keeping management controls separated.</p></div></article>
+            <article><span>01</span><div><h3>Shape the event</h3><p>Set the essentials and establish one shared source of truth for the team.</p></div></article>
+            <article><span>02</span><div><h3>Coordinate execution</h3><p>Assign ownership, follow progress and keep operational work visible.</p></div></article>
+            <article><span>03</span><div><h3>Bring people in</h3><p>Give participants a clean way to discover and join the events that matter to them.</p></div></article>
           </div>
         </div>
       </section>
 
       <section className="cta-section">
         <div className="marketing-container cta-card">
-          <div><p className="eyebrow">Ready when your team is</p><h2>Give your next event a calmer control room.</h2><p>Create an account and start organizing with Festivio.</p></div>
-          <Link to="/register" className="primary-button large">Get started <ArrowRight size={18} /></Link>
+          <div><p className="eyebrow">Festivio workspace</p><h2>A calmer control room for your next event.</h2><p>{accessToken ? 'Your workspace is ready when you are.' : 'Create an account and start coordinating your next event.'}</p></div>
+          <Link to={accessToken ? '/home' : '/register'} className="primary-button marketing-primary large">{accessToken ? 'Open workspace' : 'Get started'} <ArrowRight size={18} /></Link>
         </div>
       </section>
 
-      <footer className="marketing-footer"><div className="marketing-container"><div className="footer-brand"><span className="preview-logo">F</span><div><strong>Festivio</strong><p>Event planning and team coordination.</p></div></div><div className="footer-links"><Link to="/services">Platform</Link><Link to="/login">Sign in</Link><Link to="/register">Create account</Link></div><p>© {new Date().getFullYear()} Festivio. Open-source software.</p></div></footer>
+      <footer className="marketing-footer">
+        <div className="marketing-container footer-layout">
+          <div className="footer-brand"><span className="preview-mini-brand">F</span><div><strong>Festivio</strong><p>Event planning and team coordination.</p></div></div>
+          <div className="footer-links"><a href="#features">Features</a><a href="#workflow">How it works</a><Link to="/services">Platform</Link>{accessToken ? <Link to="/home">Workspace</Link> : <Link to="/login">Sign in</Link>}</div>
+          <p>© {new Date().getFullYear()} Festivio. Open-source software.</p>
+        </div>
+      </footer>
     </main>
   );
 };

--- a/frontend/src/features/Home/HomePage.scss
+++ b/frontend/src/features/Home/HomePage.scss
@@ -1,39 +1,50 @@
 .marketing-page {
-  color: #e8edf7;
-  background: #070c18;
-  overflow: hidden;
+  min-height: 100vh;
+  color: var(--marketing-text);
+  background:
+    radial-gradient(circle at 15% 8%, rgba(126, 123, 255, .12), transparent 30%),
+    radial-gradient(circle at 88% 12%, rgba(83, 166, 255, .11), transparent 26%),
+    var(--marketing-bg);
 }
 
-.marketing-container { width: min(1180px, calc(100% - 48px)); margin: 0 auto; }
-.hero-section { position: relative; min-height: 760px; padding: 150px 0 96px; display: flex; align-items: center; }
-.hero-glow { position: absolute; width: 520px; height: 520px; border-radius: 50%; filter: blur(120px); opacity: .2; pointer-events: none; }
-.hero-glow-one { background: #7c3aed; top: -180px; left: -120px; }
-.hero-glow-two { background: #2563eb; right: -200px; bottom: -160px; }
-.hero-layout { position: relative; display: grid; grid-template-columns: 1.05fr .95fr; gap: 74px; align-items: center; }
-.hero-copy h1 { margin: 18px 0 22px; font-size: clamp(3.2rem, 6vw, 5.6rem); line-height: .98; letter-spacing: -.065em; font-weight: 850; color: #f8fafc; }
-.hero-copy h1 span { color: #a5b4fc; }
-.hero-copy > p { max-width: 670px; color: #aab5c8; font-size: 1.12rem; line-height: 1.75; }
-.hero-badge { display: inline-flex; align-items: center; gap: 8px; border: 1px solid rgba(165,180,252,.25); background: rgba(99,102,241,.08); color: #c7d2fe; padding: 8px 12px; border-radius: 999px; font-size: .82rem; font-weight: 700; }
-.hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 34px; }
-.hero-proof { display: flex; flex-wrap: wrap; gap: 18px; margin-top: 30px; color: #8390a5; font-size: .8rem; }
-.hero-proof span { display: flex; align-items: center; gap: 6px; }
-.product-preview { border: 1px solid rgba(148,163,184,.16); border-radius: 26px; padding: 16px; background: linear-gradient(160deg, rgba(23,32,54,.92), rgba(12,18,34,.94)); box-shadow: 0 36px 100px rgba(0,0,0,.45), inset 0 1px rgba(255,255,255,.04); transform: rotate(1.2deg); }
-.preview-top { display: grid; grid-template-columns: auto 1fr auto; gap: 10px; align-items: center; padding: 4px 4px 16px; color: #dfe7f4; font-size: .8rem; font-weight: 700; }
-.preview-logo { width: 32px; height: 32px; display: grid; place-items: center; border-radius: 10px; background: linear-gradient(135deg,#7c3aed,#2563eb); color: white; font-weight: 850; }
-.preview-status { color: #86efac; background: rgba(34,197,94,.1); border: 1px solid rgba(34,197,94,.16); padding: 5px 8px; border-radius: 999px; font-size: .7rem; }
-.preview-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-.preview-panel { min-height: 150px; padding: 18px; border: 1px solid rgba(148,163,184,.12); border-radius: 18px; background: rgba(7,12,24,.65); }
-.preview-event { background: linear-gradient(145deg, rgba(79,70,229,.2), rgba(7,12,24,.7)); }
-.preview-panel h3 { margin: 7px 0 3px; font-size: 1.35rem; }
-.preview-panel p { color: #8996ab; font-size: .82rem; line-height: 1.55; }
-.preview-label { color: #68758a !important; font-size: .65rem !important; font-weight: 800; letter-spacing: .12em; }
-.preview-progress { height: 6px; margin: 24px 0 9px; background: #202b40; border-radius: 999px; overflow: hidden; }.preview-progress span { display: block; width: 78%; height: 100%; background: linear-gradient(90deg,#8b5cf6,#3b82f6); }
-.preview-panel small { color: #8895a9; }.avatar-row { display: flex; margin: 18px 0; }.avatar-row span { width: 34px; height: 34px; margin-right: -7px; border: 2px solid #11192a; border-radius: 50%; display: grid; place-items: center; background: #27344b; color: #dae3f0; font-size: .65rem; font-weight: 800; }
-.preview-tasks { grid-column: 1 / -1; min-height: auto; }.preview-tasks div { display: grid; grid-template-columns: auto 1fr auto; gap: 9px; align-items: center; padding: 10px 0; border-bottom: 1px solid rgba(148,163,184,.08); color: #cbd5e1; font-size: .78rem; }.preview-tasks div:last-child { border: 0; }.preview-tasks b { color: #8290a5; font-size: .68rem; font-weight: 600; }
-.marketing-section { padding: 110px 0; }.section-heading { max-width: 690px; margin: 0 auto 50px; text-align: center; }.section-heading.left { margin: 0; text-align: left; }.section-heading h2, .cta-card h2 { margin: 8px 0 14px; color: #f8fafc; font-size: clamp(2rem,4vw,3.3rem); line-height: 1.08; letter-spacing: -.045em; }.section-heading p, .cta-card p { color: #8f9cb0; line-height: 1.7; }.eyebrow { color: #8b9cfb !important; text-transform: uppercase; letter-spacing: .13em; font-size: .7rem !important; font-weight: 850; }
-.feature-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 14px; }.feature-grid article { padding: 26px; border: 1px solid rgba(148,163,184,.13); border-radius: 20px; background: #0b1221; }.feature-grid h3 { margin: 20px 0 9px; font-size: 1.08rem; }.feature-grid p { color: #8794a8; font-size: .88rem; line-height: 1.65; }.feature-icon { width: 44px; height: 44px; display: grid; place-items: center; border-radius: 14px; color: #c7d2fe; background: rgba(99,102,241,.13); }
-.workflow-section { background: #0a101d; border-block: 1px solid rgba(148,163,184,.08); }.workflow-layout { display: grid; grid-template-columns: .8fr 1.2fr; gap: 90px; align-items: start; }.workflow-steps { display: grid; gap: 12px; }.workflow-steps article { display: grid; grid-template-columns: 52px 1fr; gap: 18px; padding: 22px; border-radius: 18px; background: #0e1728; border: 1px solid rgba(148,163,184,.1); }.workflow-steps article > span { color: #818cf8; font-weight: 850; }.workflow-steps h3 { margin: 0 0 6px; }.workflow-steps p { margin: 0; color: #8794a8; line-height: 1.6; font-size: .88rem; }
-.cta-section { padding: 100px 0; }.cta-card { display: flex; justify-content: space-between; gap: 40px; align-items: center; padding: 54px; border-radius: 28px; border: 1px solid rgba(129,140,248,.2); background: radial-gradient(circle at top right,rgba(99,102,241,.2),transparent 40%),#0d1525; }.cta-card > div { max-width: 690px; }
-.marketing-footer { padding: 42px 0; border-top: 1px solid rgba(148,163,184,.1); }.marketing-footer .marketing-container { display: grid; grid-template-columns: 1fr auto; gap: 24px; align-items: center; }.footer-brand { display: flex; align-items: center; gap: 12px; }.footer-brand p, .marketing-footer > div > p { margin: 2px 0 0; color: #718096; font-size: .78rem; }.footer-links { display: flex; gap: 18px; }.footer-links a { color: #9aa7ba; text-decoration: none; font-size: .85rem; }.marketing-footer .marketing-container > p { grid-column: 1 / -1; }
-@media (max-width: 960px) { .hero-layout,.workflow-layout { grid-template-columns: 1fr; }.hero-section { padding-top: 130px; }.product-preview { max-width: 650px; transform: none; }.feature-grid { grid-template-columns: repeat(2,1fr); }.workflow-layout { gap: 44px; }.cta-card { align-items: flex-start; flex-direction: column; } }
-@media (max-width: 600px) { .marketing-container { width: min(100% - 30px,1180px); }.hero-section { padding: 118px 0 72px; }.hero-copy h1 { font-size: 3.25rem; }.hero-actions > * { width: 100%; justify-content: center; }.preview-grid { grid-template-columns: 1fr; }.preview-tasks { grid-column: auto; }.feature-grid { grid-template-columns: 1fr; }.marketing-section { padding: 78px 0; }.cta-card { padding: 32px 24px; }.marketing-footer .marketing-container { grid-template-columns: 1fr; }.footer-links { flex-wrap: wrap; } }
+.marketing-container { width: min(var(--container), calc(100% - 40px)); margin: 0 auto; }
+.hero-section { position: relative; overflow: hidden; padding: 154px 0 92px; }
+.hero-aurora { position: absolute; border-radius: 50%; filter: blur(70px); pointer-events: none; opacity: .55; }
+.hero-aurora-one { width: 360px; height: 360px; left: -120px; top: 180px; background: rgba(111,108,246,.18); }
+.hero-aurora-two { width: 420px; height: 420px; right: -180px; top: 80px; background: rgba(68,154,255,.14); }
+
+.hero-layout { position: relative; z-index: 1; display: grid; grid-template-columns: .9fr 1.1fr; gap: 72px; align-items: center; }
+.hero-copy { max-width: 590px; }
+.hero-badge { display: inline-flex; align-items: center; gap: 7px; padding: 7px 10px; border: 1px solid var(--marketing-border); border-radius: var(--radius-pill); background: rgba(255,255,255,.64); color: #475467; font-size: .76rem; font-weight: 700; box-shadow: var(--shadow-sm); }
+.hero-copy h1 { margin: 24px 0 20px; font-family: var(--font-display); font-size: clamp(3.4rem, 6.2vw, 6.3rem); line-height: .96; letter-spacing: -.072em; font-weight: 670; }
+.hero-copy h1 span { color: #777d89; }
+.hero-lead { max-width: 560px; margin: 0; color: var(--marketing-muted); font-size: 1.05rem; line-height: 1.75; }
+.hero-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 30px; }
+.marketing-primary { background: #111317 !important; box-shadow: 0 14px 34px rgba(17,19,23,.16) !important; }
+.marketing-primary:hover { background: #000 !important; }
+.marketing-secondary { color: #2d333c !important; border-color: rgba(17,19,23,.1) !important; background: rgba(255,255,255,.62) !important; }
+.hero-proof { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 26px; color: #697180; font-size: .74rem; font-weight: 620; }
+.hero-proof span { display: inline-flex; align-items: center; gap: 6px; }
+
+.product-preview { overflow: hidden; border: 1px solid rgba(17,19,23,.1); border-radius: 28px; background: rgba(255,255,255,.76); box-shadow: 0 34px 100px rgba(16,24,40,.14); backdrop-filter: blur(24px) saturate(140%); transform: perspective(1300px) rotateY(-2deg) rotateX(1deg); }
+.preview-window-bar { height: 48px; padding: 0 17px; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; border-bottom: 1px solid rgba(17,19,23,.07); color: #7a8190; font-size: .68rem; background: rgba(255,255,255,.52); }
+.preview-dots { display: flex; gap: 5px; }.preview-dots span { width: 8px; height: 8px; border-radius: 50%; background: #d0d5dd; }.preview-dots span:first-child{background:#ff8a80}.preview-dots span:nth-child(2){background:#ffd180}.preview-dots span:last-child{background:#8fd694}
+.preview-live { justify-self: end; color: #14804a; font-weight: 750; }
+.preview-body { min-height: 450px; display: grid; grid-template-columns: 62px 1fr; }
+.preview-sidebar { padding: 16px 11px; display: flex; flex-direction: column; align-items: center; gap: 14px; border-right: 1px solid rgba(17,19,23,.07); background: rgba(250,250,249,.82); }
+.preview-sidebar > span { width: 32px; height: 32px; border-radius: 10px; background: #eceef2; }.preview-sidebar > span.selected { background: #16191e; }
+.preview-mini-brand { width: 32px; height: 32px; display: grid; place-items: center; border-radius: 10px; background: linear-gradient(145deg, var(--brand-500), #3b82f6); color: white; font-weight: 850; font-size: .8rem; }
+.preview-content { padding: 24px; background: rgba(246,247,248,.72); }
+.preview-heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; }.preview-heading small,.preview-label,.preview-stats small{display:block;color:#98a2b3;font-size:.58rem;font-weight:800;letter-spacing:.1em}.preview-heading strong{display:block;margin-top:5px;font-size:1.02rem}.preview-heading button{border:0;border-radius:9px;padding:9px 11px;background:#111317;color:white;font-size:.65rem;font-weight:750}
+.preview-stats { display: grid; grid-template-columns: repeat(3,1fr); gap: 9px; margin: 20px 0 12px; }.preview-stats article{padding:15px;border:1px solid rgba(17,19,23,.065);border-radius:14px;background:rgba(255,255,255,.72)}.preview-stats strong{display:block;margin:8px 0 2px;font-size:1.5rem;letter-spacing:-.05em}.preview-stats span{color:#8a919f;font-size:.62rem}
+.preview-grid { display: grid; grid-template-columns: 1.1fr .9fr; gap: 10px; }.preview-panel{padding:16px;border:1px solid rgba(17,19,23,.065);border-radius:15px;background:rgba(255,255,255,.76)}.preview-panel h3{margin:12px 0 4px;font-size:.92rem}.preview-panel p{margin:0;color:#7d8491;font-size:.68rem;line-height:1.55}.preview-event{grid-row:span 2}.preview-progress{height:5px;margin:22px 0 8px;border-radius:99px;background:#e9ebef}.preview-progress span{display:block;width:78%;height:100%;border-radius:99px;background:#6b6cf4}.preview-event small{color:#7d8491;font-size:.62rem}.avatar-row{display:flex;margin:14px 0 12px}.avatar-row span{width:31px;height:31px;margin-left:-6px;display:grid;place-items:center;border:2px solid white;border-radius:50%;background:#eceef4;color:#525866;font-size:.55rem;font-weight:800}.avatar-row span:first-child{margin-left:0;background:#111317;color:#fff}.preview-tasks{display:grid;gap:9px}.preview-tasks>div{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:7px;color:#606875;font-size:.6rem}.preview-tasks b{color:#9298a3;font-size:.55rem;font-weight:700}
+
+.marketing-section { padding: 100px 0; }
+.section-heading { max-width: 720px; margin: 0 auto 48px; text-align: center; }.section-heading.left{margin:0;text-align:left}.eyebrow{margin:0;color:#6664e8;font-size:.72rem;font-weight:800;text-transform:uppercase;letter-spacing:.11em}.section-heading h2,.cta-card h2{margin:12px 0 14px;font-size:clamp(2.2rem,4vw,4rem);line-height:1.05;letter-spacing:-.055em;font-weight:650}.section-heading>p:last-child,.cta-card p:last-child{margin:0;color:var(--marketing-muted);line-height:1.75}
+.feature-grid { display:grid;grid-template-columns:repeat(4,1fr);gap:14px }.feature-grid article{min-height:230px;padding:26px;border:1px solid var(--marketing-border);border-radius:22px;background:rgba(255,255,255,.62);box-shadow:0 12px 34px rgba(16,24,40,.045);backdrop-filter:blur(12px);transition:transform var(--transition-base),box-shadow var(--transition-base)}.feature-grid article:hover{transform:translateY(-4px);box-shadow:var(--shadow-md)}.feature-icon{width:42px;height:42px;display:grid;place-items:center;border-radius:13px;background:#111317;color:white}.feature-icon svg{width:20px}.feature-grid h3{margin:28px 0 10px;font-size:1rem}.feature-grid p{margin:0;color:var(--marketing-muted);font-size:.82rem;line-height:1.7}
+.workflow-section{padding-top:70px}.workflow-layout{display:grid;grid-template-columns:.82fr 1.18fr;gap:70px;align-items:start}.workflow-steps{display:grid;gap:10px}.workflow-steps article{display:grid;grid-template-columns:50px 1fr;gap:18px;padding:22px;border-top:1px solid rgba(17,19,23,.09)}.workflow-steps>article>span{color:#a2a7b1;font-size:.68rem;font-weight:800;letter-spacing:.08em}.workflow-steps h3{margin:0 0 7px;font-size:1rem}.workflow-steps p{margin:0;color:var(--marketing-muted);font-size:.82rem;line-height:1.65}
+.cta-section{padding:30px 0 100px}.cta-card{display:flex;align-items:center;justify-content:space-between;gap:40px;padding:52px;border:1px solid rgba(17,19,23,.09);border-radius:30px;background:linear-gradient(140deg,rgba(255,255,255,.84),rgba(246,246,244,.66));box-shadow:var(--shadow-md)}.cta-card>div{max-width:720px}.cta-card h2{font-size:clamp(2.1rem,3.6vw,3.8rem)}
+.marketing-footer{padding:0 0 34px}.footer-layout{display:grid;grid-template-columns:1fr auto;gap:28px;align-items:center;padding-top:28px;border-top:1px solid rgba(17,19,23,.08)}.footer-brand{display:flex;align-items:center;gap:11px}.footer-brand strong{font-size:.88rem}.footer-brand p,.footer-layout>p{margin:3px 0 0;color:#8a919f;font-size:.68rem}.footer-links{display:flex;flex-wrap:wrap;gap:18px}.footer-links a{color:#666e7c;text-decoration:none;font-size:.72rem;font-weight:650}.footer-links a:hover{color:#111317}.footer-layout>p{grid-column:1/-1}
+
+@media (max-width: 1000px){.hero-layout,.workflow-layout{grid-template-columns:1fr}.hero-copy{max-width:760px}.product-preview{transform:none}.feature-grid{grid-template-columns:repeat(2,1fr)}.workflow-layout{gap:35px}.section-heading.left{max-width:720px;margin:0}.preview-body{min-height:400px}}
+@media (max-width: 650px){.marketing-container{width:min(100% - 28px,var(--container))}.hero-section{padding-top:125px;padding-bottom:60px}.hero-copy h1{font-size:clamp(3rem,16vw,4.4rem)}.hero-actions{display:grid}.hero-actions>a{width:100%}.hero-proof{display:grid;gap:8px}.product-preview{border-radius:20px}.preview-body{grid-template-columns:1fr}.preview-sidebar{display:none}.preview-content{padding:15px}.preview-stats{grid-template-columns:1fr 1fr 1fr}.preview-grid{grid-template-columns:1fr}.preview-event{grid-row:auto}.marketing-section{padding:70px 0}.feature-grid{grid-template-columns:1fr}.feature-grid article{min-height:auto}.cta-card{align-items:flex-start;flex-direction:column;padding:32px 24px}.cta-card>a{width:100%}.footer-layout{grid-template-columns:1fr}.footer-links{gap:14px}}

--- a/frontend/src/features/LandingPage/LandingPage.js
+++ b/frontend/src/features/LandingPage/LandingPage.js
@@ -1,28 +1,66 @@
 import React from 'react';
+import { ArrowRight, CalendarDays, ListTodo, ShieldCheck, UserRound } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { CalendarDays, ListTodo, Users } from 'lucide-react';
 import useAuthStore from '../../stores/authStore';
 import './LandingPage.scss';
 
 const roleCopy = {
-  ROLE_ADMIN: 'You have platform-wide administration access.',
-  ROLE_ORGANIZER_ADMIN: 'You can create events, coordinate participants and manage organizer tasks.',
-  ROLE_ORGANIZER: 'Your workspace focuses on the operational tasks assigned to you.',
-  ROLE_PARTICIPANT: 'Your workspace keeps upcoming events and participation close at hand.',
+  ROLE_ADMIN: 'Platform administration, event operations and team access are available from this workspace.',
+  ROLE_ORGANIZER_ADMIN: 'Create events, coordinate participants and keep organizer work moving from one place.',
+  ROLE_ORGANIZER: 'Stay focused on the operational tasks assigned to you and keep execution status current.',
+  ROLE_PARTICIPANT: 'Discover upcoming events and keep your participation close at hand.',
+};
+
+const roleLabel = {
+  ROLE_ADMIN: 'Administrator',
+  ROLE_ORGANIZER_ADMIN: 'Organizer admin',
+  ROLE_ORGANIZER: 'Organizer',
+  ROLE_PARTICIPANT: 'Participant',
 };
 
 const LandingPage = () => {
   const user = useAuthStore((state) => state.user);
   const showEvents = ['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN', 'ROLE_PARTICIPANT'].includes(user?.role);
   const showTasks = ['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN', 'ROLE_ORGANIZER'].includes(user?.role);
+  const firstName = user?.fullName?.split(' ')[0] || user?.firstName || 'there';
+
+  const cards = [
+    showEvents && { to: '/events', icon: CalendarDays, label: 'Events', copy: 'Browse event details, participation and coordination.', meta: 'Event operations' },
+    showTasks && { to: '/tasks', icon: ListTodo, label: 'Tasks', copy: 'Review assigned work and keep execution status current.', meta: 'Team execution' },
+    { to: '/profile', icon: UserRound, label: 'Your profile', copy: 'Review your account details and current access level.', meta: 'Account' },
+  ].filter(Boolean);
 
   return (
     <main className="workspace-home private-shell">
-      <section className="workspace-welcome"><p className="eyebrow">Workspace</p><h1>Welcome back{user?.fullName ? `, ${user.fullName.split(' ')[0]}` : ''}.</h1><p>{roleCopy[user?.role] || 'Your Festivio workspace is ready.'}</p></section>
-      <section className="workspace-cards">
-        {showEvents && <Link to="/events"><span><CalendarDays /></span><div><h2>Events</h2><p>Browse event details, participation and coordination.</p></div></Link>}
-        {showTasks && <Link to="/tasks"><span><ListTodo /></span><div><h2>Tasks</h2><p>See operational work and current execution status.</p></div></Link>}
-        <Link to="/profile"><span><Users /></span><div><h2>Your profile</h2><p>Review your account and current role.</p></div></Link>
+      <div className="workspace-orb workspace-orb-one" />
+      <div className="workspace-orb workspace-orb-two" />
+
+      <section className="workspace-welcome">
+        <div>
+          <p className="workspace-kicker">Workspace overview</p>
+          <h1>Welcome back, {firstName}.</h1>
+          <p>{roleCopy[user?.role] || 'Your Festivio workspace is ready.'}</p>
+        </div>
+        <div className="workspace-role-card">
+          <span className="workspace-role-icon"><ShieldCheck size={17} /></span>
+          <div><small>ACCESS</small><strong>{roleLabel[user?.role] || 'Member'}</strong></div>
+          <span className="workspace-online"><i /> Active</span>
+        </div>
+      </section>
+
+      <section className="workspace-cards" aria-label="Workspace shortcuts">
+        {cards.map(({ to, icon: Icon, label, copy, meta }) => (
+          <Link to={to} key={to}>
+            <div className="workspace-card-top"><span className="workspace-card-icon"><Icon size={20} /></span><span className="workspace-card-meta">{meta}</span></div>
+            <div className="workspace-card-copy"><h2>{label}</h2><p>{copy}</p></div>
+            <span className="workspace-card-action">Open <ArrowRight size={15} /></span>
+          </Link>
+        ))}
+      </section>
+
+      <section className="workspace-note">
+        <div><span>F</span><div><strong>Festivio workspace</strong><p>The application area is intentionally separated from the public website so your operational navigation stays focused.</p></div></div>
+        <Link to="/">View public website <ArrowRight size={14} /></Link>
       </section>
     </main>
   );

--- a/frontend/src/features/LandingPage/LandingPage.scss
+++ b/frontend/src/features/LandingPage/LandingPage.scss
@@ -1,1 +1,30 @@
-.workspace-home { background: radial-gradient(circle at 20% 0,rgba(99,102,241,.13),transparent 34%),#070c18; }.workspace-welcome { max-width: 760px; padding: 50px 0 34px; }.workspace-welcome h1 { margin: 8px 0 12px; font-size: clamp(2.4rem,5vw,4rem); letter-spacing: -.05em; }.workspace-welcome > p:last-child { color: #95a2b7; line-height: 1.7; }.workspace-cards { display: grid; grid-template-columns: repeat(3,1fr); gap: 16px; }.workspace-cards a { min-height: 190px; padding: 28px; display: flex; flex-direction: column; justify-content: space-between; border-radius: 22px; border: 1px solid rgba(148,163,184,.13); background: #0c1424; color: #f8fafc; text-decoration: none; transition: transform .2s,border-color .2s; }.workspace-cards a:hover { transform: translateY(-3px); border-color: rgba(129,140,248,.4); }.workspace-cards span { width: 44px; height: 44px; display: grid; place-items:center; border-radius: 14px; background: rgba(99,102,241,.13); color:#c7d2fe; }.workspace-cards h2 { margin: 18px 0 7px; }.workspace-cards p { margin:0;color:#8390a5;line-height:1.55;font-size:.88rem;}@media(max-width:760px){.workspace-cards{grid-template-columns:1fr}}
+.workspace-home { position: relative; overflow: hidden; }
+.workspace-orb { position: absolute; border-radius: 50%; filter: blur(100px); opacity: .22; pointer-events: none; }
+.workspace-orb-one { width: 340px; height: 340px; top: 40px; left: -140px; background: #6f6cf6; }
+.workspace-orb-two { width: 360px; height: 360px; right: -150px; bottom: 10%; background: #3b82f6; }
+
+.workspace-welcome { position: relative; z-index: 1; display: flex; align-items: flex-end; justify-content: space-between; gap: 40px; margin-bottom: 34px; }
+.workspace-welcome > div:first-child { max-width: 720px; }
+.workspace-kicker { margin: 0 0 10px; color: #8f8cff; font-size: .7rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.workspace-welcome h1 { margin: 0; color: var(--app-text); font-size: clamp(2.5rem, 5vw, 4.6rem); line-height: .98; letter-spacing: -.06em; font-weight: 670; }
+.workspace-welcome > div:first-child > p:last-child { margin: 16px 0 0; max-width: 640px; color: var(--app-muted); line-height: 1.7; }
+.workspace-role-card { min-width: 270px; display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 12px; padding: 16px; border: 1px solid var(--app-border); border-radius: 17px; background: var(--app-surface); box-shadow: var(--shadow-dark); backdrop-filter: blur(18px); }
+.workspace-role-icon { width: 38px; height: 38px; display: grid; place-items: center; border-radius: 12px; background: var(--brand-soft); color: #a9a7ff; }
+.workspace-role-card small { display: block; margin-bottom: 3px; color: #697386; font-size: .55rem; font-weight: 800; letter-spacing: .1em; }
+.workspace-role-card strong { color: #edf0f7; font-size: .8rem; }
+.workspace-online { display: inline-flex; align-items: center; gap: 5px; color: #9aa5b6; font-size: .62rem; font-weight: 700; }.workspace-online i{width:6px;height:6px;border-radius:50%;background:#22c55e;box-shadow:0 0 0 3px rgba(34,197,94,.1)}
+
+.workspace-cards { position: relative; z-index: 1; display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+.workspace-cards > a { min-height: 250px; padding: 22px; display: flex; flex-direction: column; border: 1px solid var(--app-border); border-radius: 22px; background: linear-gradient(155deg, rgba(20,26,38,.88), rgba(11,15,23,.82)); color: inherit; text-decoration: none; box-shadow: 0 18px 60px rgba(0,0,0,.18); transition: transform var(--transition-base), border-color var(--transition-base), background var(--transition-base); }
+.workspace-cards > a:hover { transform: translateY(-4px); border-color: rgba(138,135,255,.28); background: linear-gradient(155deg, rgba(25,31,46,.94), rgba(12,17,26,.9)); }
+.workspace-card-top { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.workspace-card-icon { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 13px; color: #b2b0ff; background: rgba(111,108,246,.11); border: 1px solid rgba(138,135,255,.12); }
+.workspace-card-meta { color: #687487; font-size: .62rem; font-weight: 750; text-transform: uppercase; letter-spacing: .08em; }
+.workspace-card-copy { margin-top: auto; }.workspace-card-copy h2{margin:0 0 9px;color:#f4f6fb;font-size:1.15rem;letter-spacing:-.025em}.workspace-card-copy p{margin:0;color:#8895a7;font-size:.82rem;line-height:1.65}
+.workspace-card-action { margin-top: 20px; display: inline-flex; align-items: center; gap: 6px; color: #b8c0cf; font-size: .72rem; font-weight: 700; }
+
+.workspace-note { position: relative; z-index: 1; margin-top: 14px; padding: 18px 20px; display: flex; align-items: center; justify-content: space-between; gap: 24px; border: 1px solid var(--app-border); border-radius: 18px; background: rgba(255,255,255,.028); }
+.workspace-note > div { display: flex; align-items: center; gap: 12px; }.workspace-note > div > span{width:34px;height:34px;display:grid;place-items:center;border-radius:10px;background:rgba(255,255,255,.06);color:#d8dce5;font-weight:800}.workspace-note strong{display:block;color:#dfe3ec;font-size:.76rem}.workspace-note p{margin:4px 0 0;color:#707c8f;font-size:.7rem;line-height:1.5}.workspace-note>a{display:inline-flex;align-items:center;gap:6px;white-space:nowrap;color:#a9a7ff;text-decoration:none;font-size:.7rem;font-weight:700}
+
+@media(max-width:900px){.workspace-welcome{align-items:flex-start;flex-direction:column}.workspace-role-card{width:100%;min-width:0}.workspace-cards{grid-template-columns:1fr 1fr}.workspace-note{align-items:flex-start;flex-direction:column}}
+@media(max-width:620px){.workspace-cards{grid-template-columns:1fr}.workspace-cards>a{min-height:220px}.workspace-welcome{margin-bottom:24px}.workspace-role-card{grid-template-columns:auto 1fr}.workspace-online{grid-column:2}.workspace-note>a{white-space:normal}}

--- a/frontend/src/features/Task/TaskPage.scss
+++ b/frontend/src/features/Task/TaskPage.scss
@@ -1,1 +1,15 @@
-.task-toolbar{display:flex;gap:10px;margin-bottom:20px}.task-toolbar input,.task-toolbar select,.task-card select{border:1px solid rgba(148,163,184,.16);border-radius:11px;padding:10px 12px;background:#0c1424;color:#e8edf7;outline:none}.task-toolbar input{flex:1}.task-list{display:grid;gap:12px}.task-card{display:flex;justify-content:space-between;gap:24px;align-items:center;padding:24px;border:1px solid rgba(148,163,184,.13);border-radius:18px;background:#0c1424}.task-card h2{margin:11px 0 7px;font-size:1.08rem}.task-card p{margin:0 0 12px;color:#8491a6;font-size:.87rem;line-height:1.55}.task-card small{color:#6f7d92}.task-status-badge{display:inline-flex;padding:4px 8px;border-radius:999px;font-size:.68rem;font-weight:750;color:#cbd5e1;background:#1e293b}.task-status-badge.completed{color:#bbf7d0;background:rgba(34,197,94,.12)}.task-status-badge.in-progress{color:#fde68a;background:rgba(245,158,11,.12)}.task-status-badge.pending{color:#c7d2fe;background:rgba(99,102,241,.12)}@media(max-width:650px){.task-toolbar,.task-card{align-items:stretch;flex-direction:column}.task-card select{width:100%}}
+.task-toolbar { display: flex; gap: 10px; margin-bottom: 20px; }
+.task-toolbar input, .task-toolbar select, .task-card select { border: 1px solid var(--app-border); border-radius: 12px; padding: 10px 12px; background: var(--app-surface); color: var(--app-text); outline: none; transition: border-color var(--transition-fast), background var(--transition-fast), box-shadow var(--transition-fast); }
+.task-toolbar input:focus, .task-toolbar select:focus, .task-card select:focus { border-color: rgba(138,135,255,.48); box-shadow: 0 0 0 3px rgba(111,108,246,.1); background: var(--app-surface-strong); }
+.task-toolbar input { flex: 1; }
+.task-list { display: grid; gap: 12px; }
+.task-card { display: flex; justify-content: space-between; gap: 24px; align-items: center; padding: 24px; border: 1px solid var(--app-border); border-radius: 19px; background: linear-gradient(155deg, rgba(18,24,35,.92), rgba(11,15,23,.88)); box-shadow: 0 14px 44px rgba(0,0,0,.12); transition: transform var(--transition-base), border-color var(--transition-base); }
+.task-card:hover { transform: translateY(-2px); border-color: rgba(138,135,255,.22); }
+.task-card h2 { margin: 11px 0 7px; font-size: 1.05rem; letter-spacing: -.02em; }
+.task-card p { margin: 0 0 12px; color: #8491a6; font-size: .84rem; line-height: 1.6; }
+.task-card small { color: #6f7d92; }
+.task-status-badge { display: inline-flex; padding: 5px 8px; border-radius: var(--radius-pill); font-size: .66rem; font-weight: 750; color: #cbd5e1; background: #1e293b; }
+.task-status-badge.completed { color: #bbf7d0; background: rgba(34,197,94,.12); }
+.task-status-badge.in-progress { color: #fde68a; background: rgba(245,158,11,.12); }
+.task-status-badge.pending { color: #c7d2fe; background: rgba(99,102,241,.12); }
+@media(max-width:650px){.task-toolbar,.task-card{align-items:stretch;flex-direction:column}.task-card select{width:100%}}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,19 +2,90 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background:#070c18; }
+:root { color-scheme: dark; font-family: var(--font-sans); background: var(--app-bg); }
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; }
-body { margin:0; min-width:320px; background:#070c18; color:#e8edf7; -webkit-font-smoothing:antialiased; }
-button,input,textarea,select { font:inherit; }
-button { cursor:pointer; }
-a { color:inherit; }
+body { margin: 0; min-width: 320px; background: var(--app-bg); color: var(--app-text); -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; }
+button, input, textarea, select { font: inherit; }
+button { cursor: pointer; }
+a { color: inherit; }
+::selection { background: rgba(111,108,246,.28); color: inherit; }
 
-.primary-button,.secondary-button { display:inline-flex;align-items:center;justify-content:center;gap:8px;border-radius:12px;padding:10px 16px;border:1px solid transparent;font-weight:750;font-size:.9rem;text-decoration:none;transition:transform .18s,background .18s,border-color .18s; }
-.primary-button { color:white;background:linear-gradient(135deg,#7c3aed,#2563eb);box-shadow:0 10px 28px rgba(79,70,229,.22); }.primary-button:hover{transform:translateY(-1px);background:linear-gradient(135deg,#8b5cf6,#3b82f6)}.primary-button:disabled{opacity:.6;cursor:not-allowed;transform:none}.secondary-button{color:#d7deea;border-color:rgba(148,163,184,.22);background:rgba(255,255,255,.035)}.secondary-button:hover{border-color:rgba(165,180,252,.42);background:rgba(255,255,255,.06)}.secondary-button.danger{color:#fca5a5;border-color:rgba(248,113,113,.22)}.large{padding:13px 19px;border-radius:14px}.full-width{width:100%}
-.app-loading{min-height:100vh;display:flex;align-items:center;justify-content:center;gap:12px;background:#070c18;color:#aab5c8}.app-loading-mark{width:42px;height:42px;display:grid;place-items:center;border-radius:14px;background:linear-gradient(135deg,#7c3aed,#2563eb);color:white;font-weight:850}
-.auth-shell{min-height:100vh;padding:122px 20px 60px;display:grid;place-items:center;background:radial-gradient(circle at 50% 0,rgba(99,102,241,.16),transparent 35%),#070c18}.auth-card{width:min(460px,100%);padding:34px;border:1px solid rgba(148,163,184,.15);border-radius:24px;background:#0c1424;box-shadow:0 28px 90px rgba(0,0,0,.35)}.auth-card-wide{width:min(660px,100%)}.auth-brand{display:inline-block;margin-bottom:30px;color:#f8fafc;font-weight:850;text-decoration:none;font-size:1.15rem}.auth-card h1{margin:5px 0 8px;font-size:2rem;letter-spacing:-.04em}.auth-subtitle{margin:0;color:#8896aa;line-height:1.65;font-size:.9rem}.auth-form{display:grid;gap:17px;margin-top:26px}.auth-form label,.stack-form label{display:grid;gap:7px;color:#bec8d8;font-size:.78rem;font-weight:700}.auth-form input,.auth-form select,.stack-form input,.stack-form textarea,.stack-form select{width:100%;border:1px solid rgba(148,163,184,.18);border-radius:11px;padding:11px 12px;background:#08101f;color:#eef2f7;outline:none}.auth-form input:focus,.auth-form select:focus,.stack-form input:focus,.stack-form textarea:focus{border-color:#6366f1;box-shadow:0 0 0 3px rgba(99,102,241,.12)}.auth-grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}.auth-row{display:flex;justify-content:space-between;font-size:.78rem}.auth-row a,.auth-footnote a{color:#a5b4fc;text-decoration:none}.auth-footnote{text-align:center;color:#8190a5;font-size:.8rem;margin:20px 0 0}.auth-alert{margin-top:18px;padding:11px 13px;border-radius:10px;font-size:.8rem}.auth-alert-error{color:#fecaca;background:rgba(239,68,68,.1);border:1px solid rgba(239,68,68,.15)}.auth-alert-success{color:#bbf7d0;background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.15)}.checkbox-label{display:flex!important;grid-template-columns:auto 1fr!important;align-items:center;gap:9px!important}.checkbox-label input{width:auto!important}
-.private-shell{min-height:100vh;padding:122px max(24px,calc((100vw - 1180px)/2)) 70px;background:#070c18;color:#e8edf7}.page-heading{display:flex;justify-content:space-between;align-items:flex-end;gap:30px;margin-bottom:34px}.page-heading h1{margin:5px 0 8px;font-size:2.7rem;letter-spacing:-.045em}.page-heading p:last-child{margin:0;color:#8592a6}.event-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}.event-card{overflow:hidden;border:1px solid rgba(148,163,184,.13);border-radius:20px;background:#0c1424}.event-card-main{width:100%;padding:0;border:0;text-align:left;color:inherit;background:transparent}.event-card-main img,.event-image-placeholder{width:100%;height:190px;object-fit:cover}.event-image-placeholder{display:grid;place-items:center;font-size:3rem;font-weight:850;color:#a5b4fc;background:linear-gradient(145deg,#172554,#312e81)}.event-card-body{padding:20px}.event-card-body h2{margin:10px 0 7px;font-size:1.2rem}.event-card-body p{color:#8794a8;line-height:1.55;font-size:.84rem;min-height:42px}.event-meta{display:flex;align-items:center;gap:7px;color:#758399;font-size:.72rem}.event-card-action{padding:0 20px 20px}.event-card-action button{width:100%}.empty-state,.inline-alert{padding:20px;border-radius:14px;border:1px solid rgba(148,163,184,.13);background:#0c1424;color:#8996a9}.inline-alert{margin-bottom:20px;color:#fecaca;border-color:rgba(239,68,68,.18)}
-.modal-overlay{position:fixed;inset:0;z-index:120;display:grid;place-items:center;padding:20px;background:rgba(2,6,23,.78);backdrop-filter:blur(8px)}.modal-panel{width:min(520px,100%);max-height:90vh;overflow:auto;padding:28px;border:1px solid rgba(148,163,184,.16);border-radius:22px;background:#0c1424;box-shadow:0 30px 100px rgba(0,0,0,.5)}.modal-heading{display:flex;justify-content:space-between;gap:20px}.modal-heading h2{margin:5px 0 20px}.icon-button{width:36px;height:36px;border:1px solid rgba(148,163,184,.15);border-radius:10px;background:#111b2d;color:white;font-size:1.4rem}.stack-form{display:grid;gap:16px}.stack-form small{color:#69778d}.modal-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:8px}.image-preview{width:100%;height:150px;object-fit:cover;border-radius:12px}
-.profile-card{display:flex;align-items:center;gap:22px;padding:28px;border:1px solid rgba(148,163,184,.13);border-radius:22px;background:#0c1424}.profile-avatar{width:76px;height:76px;display:grid;place-items:center;border-radius:22px;background:linear-gradient(135deg,#7c3aed,#2563eb);font-size:1.5rem;font-weight:850}.profile-copy h2{margin:0 0 5px}.profile-copy p{margin:0 0 12px;color:#8592a6}.role-pill{display:inline-flex;padding:5px 9px;border-radius:999px;color:#c7d2fe;background:rgba(99,102,241,.12);font-size:.72rem;font-weight:750}.profile-details{display:grid;grid-template-columns:repeat(3,1fr);gap:12px;margin-top:14px}.profile-details div{padding:20px;border:1px solid rgba(148,163,184,.12);border-radius:16px;background:#0c1424}.profile-details span{display:block;margin-bottom:7px;color:#718096;font-size:.7rem;text-transform:uppercase;letter-spacing:.09em}.profile-details strong{font-size:.9rem}
-@media(max-width:900px){.event-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:650px){.auth-grid,.event-grid,.profile-details{grid-template-columns:1fr}.page-heading{align-items:flex-start;flex-direction:column}.private-shell{padding-inline:16px}.auth-card{padding:26px 20px}}
+.primary-button, .secondary-button { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 40px; border-radius: var(--radius-md); padding: 10px 16px; border: 1px solid transparent; font-weight: 750; font-size: .84rem; text-decoration: none; transition: transform var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast); }
+.primary-button { color: #fff; background: linear-gradient(135deg, var(--brand-500), #3b82f6); box-shadow: 0 10px 28px rgba(79,70,229,.22); }
+.primary-button:hover { transform: translateY(-1px); background: linear-gradient(135deg, var(--brand-400), #4f8ef7); }
+.primary-button:focus-visible, .secondary-button:focus-visible, button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible { outline: 2px solid #9b99ff; outline-offset: 2px; }
+.primary-button:disabled { opacity: .6; cursor: not-allowed; transform: none; }
+.secondary-button { color: #d7deea; border-color: var(--app-border); background: rgba(255,255,255,.035); }
+.secondary-button:hover { border-color: rgba(165,180,252,.34); background: rgba(255,255,255,.065); }
+.secondary-button.danger { color: #fda4af; border-color: rgba(248,113,113,.2); }
+.large { padding: 13px 19px; min-height: 46px; border-radius: 14px; }
+.full-width { width: 100%; }
+
+.app-loading { min-height: 100vh; display: flex; align-items: center; justify-content: center; gap: 12px; background: radial-gradient(circle at 50% 25%, rgba(111,108,246,.15), transparent 30%), var(--app-bg); color: #9ba6b7; }
+.app-loading-mark { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 14px; background: linear-gradient(135deg, var(--brand-500), #3b82f6); color: white; font-weight: 850; box-shadow: 0 14px 34px rgba(79,70,229,.24); }
+
+.auth-shell { min-height: 100vh; padding: 122px 20px 60px; display: grid; place-items: center; background: radial-gradient(circle at 50% 0, rgba(99,102,241,.15), transparent 34%), var(--app-bg); }
+.auth-card { width: min(460px,100%); padding: 34px; border: 1px solid var(--app-border); border-radius: 24px; background: rgba(12,17,26,.9); box-shadow: var(--shadow-dark); backdrop-filter: blur(18px); }
+.auth-card-wide { width: min(660px,100%); }
+.auth-brand { display: inline-block; margin-bottom: 30px; color: #f8fafc; font-weight: 850; text-decoration: none; font-size: 1.15rem; }
+.auth-card h1 { margin: 5px 0 8px; font-size: 2rem; letter-spacing: -.04em; }
+.auth-subtitle { margin: 0; color: #8996a9; line-height: 1.65; font-size: .88rem; }
+.auth-form { display: grid; gap: 17px; margin-top: 26px; }
+.auth-form label, .stack-form label { display: grid; gap: 7px; color: #bec8d8; font-size: .76rem; font-weight: 700; }
+.auth-form input, .auth-form select, .stack-form input, .stack-form textarea, .stack-form select { width: 100%; border: 1px solid var(--app-border); border-radius: 11px; padding: 11px 12px; background: rgba(5,9,16,.8); color: #eef2f7; outline: none; transition: border-color var(--transition-fast), box-shadow var(--transition-fast), background var(--transition-fast); }
+.auth-form input:focus, .auth-form select:focus, .stack-form input:focus, .stack-form textarea:focus, .stack-form select:focus { border-color: #7773f7; box-shadow: 0 0 0 3px rgba(99,102,241,.12); background: #080d15; }
+.auth-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.auth-row { display: flex; justify-content: space-between; font-size: .76rem; }
+.auth-row a, .auth-footnote a { color: #aaa8ff; text-decoration: none; }
+.auth-footnote { text-align: center; color: #8190a5; font-size: .78rem; margin: 20px 0 0; }
+.auth-alert { margin-top: 18px; padding: 11px 13px; border-radius: 10px; font-size: .78rem; }
+.auth-alert-error { color: #fecaca; background: rgba(239,68,68,.1); border: 1px solid rgba(239,68,68,.15); }
+.auth-alert-success { color: #bbf7d0; background: rgba(34,197,94,.1); border: 1px solid rgba(34,197,94,.15); }
+.checkbox-label { display: flex !important; grid-template-columns: auto 1fr !important; align-items: center; gap: 9px !important; }
+.checkbox-label input { width: auto !important; }
+
+.private-shell { min-height: 100vh; padding: 124px max(24px, calc((100vw - var(--container))/2)) 72px; background: radial-gradient(circle at 15% 8%, rgba(111,108,246,.08), transparent 28%), var(--app-bg); color: var(--app-text); }
+.page-heading { display: flex; justify-content: space-between; align-items: flex-end; gap: 30px; margin-bottom: 34px; }
+.page-heading h1 { margin: 5px 0 8px; font-size: clamp(2.35rem,5vw,4.3rem); line-height: 1; letter-spacing: -.055em; font-weight: 670; }
+.page-heading p:last-child { margin: 0; color: var(--app-muted); line-height: 1.6; }
+.private-shell .eyebrow { color: #9693ff; }
+
+.event-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: 14px; }
+.event-card { overflow: hidden; border: 1px solid var(--app-border); border-radius: 21px; background: linear-gradient(160deg, rgba(18,24,35,.92), rgba(11,15,23,.9)); box-shadow: 0 18px 50px rgba(0,0,0,.14); transition: transform var(--transition-base), border-color var(--transition-base); }
+.event-card:hover { transform: translateY(-3px); border-color: rgba(138,135,255,.22); }
+.event-card-main { width: 100%; padding: 0; border: 0; text-align: left; color: inherit; background: transparent; }
+.event-card-main img, .event-image-placeholder { width: 100%; height: 190px; object-fit: cover; }
+.event-image-placeholder { display: grid; place-items: center; font-size: 3rem; font-weight: 850; color: #c2c0ff; background: radial-gradient(circle at 30% 20%, rgba(111,108,246,.35), transparent 45%), linear-gradient(145deg,#101728,#1c2340); }
+.event-card-body { padding: 20px; }
+.event-card-body h2 { margin: 10px 0 7px; font-size: 1.1rem; letter-spacing: -.02em; }
+.event-card-body p { color: #8794a8; line-height: 1.55; font-size: .82rem; min-height: 42px; }
+.event-meta { display: flex; align-items: center; gap: 7px; color: #758399; font-size: .7rem; }
+.event-card-action { padding: 0 20px 20px; }
+.event-card-action button { width: 100%; }
+.empty-state, .inline-alert { padding: 20px; border-radius: 15px; border: 1px solid var(--app-border); background: var(--app-surface); color: #8996a9; }
+.empty-state { grid-column: 1 / -1; }
+.inline-alert { margin-bottom: 20px; color: #fecaca; border-color: rgba(239,68,68,.18); }
+
+.modal-overlay { position: fixed; inset: 0; z-index: 120; display: grid; place-items: center; padding: 20px; background: rgba(2,6,12,.76); backdrop-filter: blur(10px); }
+.modal-panel { width: min(520px,100%); max-height: 90vh; overflow: auto; padding: 28px; border: 1px solid var(--app-border); border-radius: 22px; background: rgba(13,18,28,.96); box-shadow: 0 30px 100px rgba(0,0,0,.5); }
+.modal-heading { display: flex; justify-content: space-between; gap: 20px; }
+.modal-heading h2 { margin: 5px 0 20px; }
+.icon-button { width: 36px; height: 36px; border: 1px solid var(--app-border); border-radius: 10px; background: rgba(255,255,255,.04); color: white; font-size: 1.4rem; }
+.stack-form { display: grid; gap: 16px; }
+.stack-form small { color: #69778d; }
+.modal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 8px; }
+.image-preview { width: 100%; height: 150px; object-fit: cover; border-radius: 12px; }
+
+.profile-card { display: flex; align-items: center; gap: 22px; padding: 28px; border: 1px solid var(--app-border); border-radius: 22px; background: linear-gradient(155deg, rgba(18,24,35,.92), rgba(11,15,23,.88)); box-shadow: 0 18px 50px rgba(0,0,0,.14); }
+.profile-avatar { width: 76px; height: 76px; display: grid; place-items: center; border-radius: 22px; background: linear-gradient(135deg,var(--brand-500),#3b82f6); font-size: 1.5rem; font-weight: 850; box-shadow: 0 14px 34px rgba(79,70,229,.2); }
+.profile-copy h2 { margin: 0 0 5px; }
+.profile-copy p { margin: 0 0 12px; color: #8592a6; }
+.role-pill { display: inline-flex; padding: 5px 9px; border-radius: var(--radius-pill); color: #c7d2fe; background: rgba(99,102,241,.12); font-size: .7rem; font-weight: 750; }
+.profile-details { display: grid; grid-template-columns: repeat(3,1fr); gap: 12px; margin-top: 14px; }
+.profile-details div { padding: 20px; border: 1px solid var(--app-border); border-radius: 16px; background: var(--app-surface); }
+.profile-details span { display: block; margin-bottom: 7px; color: #718096; font-size: .68rem; text-transform: uppercase; letter-spacing: .09em; }
+.profile-details strong { font-size: .86rem; }
+
+@media(max-width:900px){.event-grid{grid-template-columns:repeat(2,1fr)}}
+@media(max-width:650px){.auth-grid,.event-grid,.profile-details{grid-template-columns:1fr}.page-heading{align-items:flex-start;flex-direction:column}.private-shell{padding:108px 16px 56px}.auth-card{padding:26px 20px}.modal-actions{flex-direction:column-reverse}.modal-actions button{width:100%}}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import './styles/tokens.css';
 import './index.css';
 import App from './App';
 

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,70 @@
+:root {
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-display: "SF Pro Display", Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  --ink-950: #05070b;
+  --ink-900: #0a0d13;
+  --ink-850: #0f131c;
+  --ink-800: #151a24;
+  --ink-700: #252c39;
+  --ink-500: #667085;
+  --ink-400: #98a2b3;
+  --ink-200: #d0d5dd;
+  --ink-100: #eaecf0;
+  --ink-50: #f7f8fa;
+  --white: #ffffff;
+
+  --brand-700: #4f46e5;
+  --brand-600: #5b5cf0;
+  --brand-500: #6f6cf6;
+  --brand-400: #8a87ff;
+  --brand-soft: rgba(111, 108, 246, 0.12);
+  --sky-soft: rgba(73, 150, 255, 0.13);
+
+  --success: #12b76a;
+  --danger: #f04438;
+  --warning: #f79009;
+
+  --marketing-bg: #f5f5f2;
+  --marketing-surface: rgba(255, 255, 255, 0.72);
+  --marketing-surface-strong: rgba(255, 255, 255, 0.9);
+  --marketing-border: rgba(16, 24, 40, 0.08);
+  --marketing-text: #111317;
+  --marketing-muted: #667085;
+
+  --app-bg: #070a10;
+  --app-surface: rgba(16, 21, 31, 0.82);
+  --app-surface-strong: #0f141d;
+  --app-surface-soft: rgba(255, 255, 255, 0.045);
+  --app-border: rgba(255, 255, 255, 0.085);
+  --app-text: #f4f6fb;
+  --app-muted: #98a2b3;
+
+  --glass-blur: 22px;
+  --shadow-sm: 0 8px 24px rgba(16, 24, 40, 0.06);
+  --shadow-md: 0 24px 70px rgba(16, 24, 40, 0.12);
+  --shadow-dark: 0 28px 90px rgba(0, 0, 0, 0.3);
+
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-xl: 28px;
+  --radius-pill: 999px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+  --space-20: 80px;
+
+  --container: 1180px;
+  --header-height: 72px;
+  --transition-fast: 160ms cubic-bezier(0.2, 0.7, 0.2, 1);
+  --transition-base: 240ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}


### PR DESCRIPTION
## Summary

- separates the public website navigation from the authenticated workspace navigation while keeping one React application
- adds session-aware public CTAs: sign in/get started when logged out, open workspace when authenticated
- adds a focused workspace header with Website, Overview, Events, Tasks, Profile and Sign out actions according to role
- redesigns the marketing landing page with a minimal Apple/OpenAI-inspired glass aesthetic
- redesigns the authenticated workspace overview with a distinct dark operational visual language
- introduces centralized design tokens for typography, colors, spacing, radii, shadows and transitions
- refreshes shared app surfaces, event cards, forms, modals, profile surfaces and task cards without changing backend/API behavior
- keeps existing `/home`, `/events`, `/tasks`, `/profile` routes and role checks to avoid functional regressions
- adds navigation-mode tests for public/authenticated/workspace states

## Production-readiness constraints

- no backend or API contract changes
- no authentication/session flow changes
- no role/permission logic changes
- no route removals
- responsive navigation and keyboard focus states included

## Validation

CI should run the existing frontend tests/build plus repository integrity and Compose checks. The current execution environment could not access GitHub/npm directly for a local install, so the repository CI is the source of truth for the final validation.