### PR TITLE
release: promote develop to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [1.1.0](https://github.com/chouaib-skitou/Festivio/compare/v1.0.0...v1.1.0) (2026-09-06)
+
+
+### Features
+
+* **frontend:** add marketing navigation shell ([57893e3](https://github.com/chouaib-skitou/Festivio/commit/57893e3f7bdb403f94ca5782f7b8e97d15d6c22f))
+* **frontend:** add shared brand component ([30d1018](https://github.com/chouaib-skitou/Festivio/commit/30d101877ef4f73e23ae4ef7b2d0b90af748520c))
+* **frontend:** add shared design tokens ([8019f8e](https://github.com/chouaib-skitou/Festivio/commit/8019f8e0dcc61c66611bd6c98b14a8ca969ce7e8))
+* **frontend:** add workspace navigation shell ([7dcb6b8](https://github.com/chouaib-skitou/Festivio/commit/7dcb6b821e3847227e3e38715b19d516e9c95137))
+* **frontend:** redesign marketing landing experience ([d29a2c3](https://github.com/chouaib-skitou/Festivio/commit/d29a2c39d4e788e627db124c71a4f173f405c5ca))
+* **frontend:** redesign workspace overview ([ad3c23a](https://github.com/chouaib-skitou/Festivio/commit/ad3c23a5ff5f477f47c5043b343345a4bc73a94d))
+
 # 1.0.0 (2026-09-05)
 
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "festivio-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Festivio Node.js and Express backend with MongoDB",
   "main": "server.js",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "festivio-frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Festivio">
+  <defs>
+    <linearGradient id="g" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8A87FF"/>
+      <stop offset="1" stop-color="#3B82F6"/>
+    </linearGradient>
+    <filter id="s" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="3" stdDeviation="3" flood-color="#4F46E5" flood-opacity=".28"/>
+    </filter>
+  </defs>
+  <rect x="5" y="5" width="54" height="54" rx="17" fill="url(#g)" filter="url(#s)"/>
+  <path d="M22 17.5h23v7H30v7.2h12.5v6.8H30V47h-8V17.5Z" fill="white"/>
+</svg>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,43 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#f5f5f2" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Festivio — event planning, team coordination and participant management in one focused workspace."
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <title>Festivio</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>You need to enable JavaScript to run Festivio.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,25 +1,15 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Festivio",
+  "name": "Festivio",
   "icons": [
     {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
     }
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#f5f5f2",
+  "background_color": "#f5f5f2"
 }

--- a/frontend/src/components/NavBar/MarketingNav.js
+++ b/frontend/src/components/NavBar/MarketingNav.js
@@ -22,7 +22,6 @@ const MarketingNav = ({ open, setOpen }) => {
         <div className={`navbar-links marketing-links ${open ? 'open' : ''}`}>
           <a href="/#features" onClick={close}>Features</a>
           <a href="/#workflow" onClick={close}>How it works</a>
-          <Link to="/services" className={active('/services')} onClick={close}>Platform</Link>
           {accessToken ? (
             <Link to="/home" className="nav-cta" onClick={close}>Open workspace <ArrowRight size={16} /></Link>
           ) : (

--- a/frontend/src/components/NavBar/NavBar.scss
+++ b/frontend/src/components/NavBar/NavBar.scss
@@ -29,6 +29,7 @@
   content: '';
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   pointer-events: none;
   background: linear-gradient(115deg, rgba(255,255,255,.26), transparent 28%, transparent 72%, rgba(255,255,255,.08));
   opacity: .7;
@@ -136,10 +137,21 @@
   width: 38px;
   height: 38px;
   place-items: center;
-  border: 0;
+  flex: 0 0 38px;
+  border: 1px solid transparent;
   border-radius: 11px;
   background: transparent;
   color: inherit;
+}
+
+.menu-toggle:hover {
+  background: rgba(255,255,255,.24);
+  border-color: rgba(255,255,255,.44);
+}
+
+.workspace-navbar .menu-toggle:hover {
+  background: rgba(255,255,255,.06);
+  border-color: rgba(255,255,255,.08);
 }
 
 @media (prefers-reduced-transparency: reduce) {
@@ -147,26 +159,75 @@
 }
 
 @media (max-width: 820px) {
-  .site-header { padding: 10px 10px 0; }
-  .navbar { width: 100%; min-height: 56px; position: relative; }
-  .menu-toggle { display: grid; }
-  .workspace-label, .workspace-divider { display: none; }
+  .site-header {
+    padding: 10px 10px 0;
+  }
+
+  .navbar {
+    width: 100%;
+    min-height: 56px;
+    position: relative;
+    overflow: visible;
+  }
+
+  .navbar::before {
+    clip-path: inset(0 round 19px);
+  }
+
+  .menu-toggle {
+    display: grid;
+    z-index: 4;
+  }
+
+  .workspace-label,
+  .workspace-divider {
+    display: none;
+  }
+
   .navbar-links {
     position: absolute;
+    z-index: 3;
     top: calc(100% + 8px);
     left: 0;
     right: 0;
     display: none;
+    max-height: calc(100vh - 92px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 10px;
     border: 1px solid transparent;
-    border-radius: 16px;
-    box-shadow: var(--shadow-md);
-    backdrop-filter: blur(28px) saturate(180%);
-    -webkit-backdrop-filter: blur(28px) saturate(180%);
+    border-radius: 17px;
+    box-shadow: 0 24px 70px rgba(16,24,40,.14), inset 0 1px 0 rgba(255,255,255,.72);
+    backdrop-filter: blur(32px) saturate(190%);
+    -webkit-backdrop-filter: blur(32px) saturate(190%);
+    pointer-events: auto;
   }
-  .marketing-links { background: rgba(255,255,255,.66); border-color: rgba(255,255,255,.82); }
-  .workspace-links { background: rgba(10,14,21,.96); border-color: var(--app-border); }
-  .navbar-links.open { display: grid; }
-  .navbar-links a, .nav-quiet-button { width: 100%; justify-content: flex-start; min-height: 44px; }
-  .navbar-links .nav-cta { margin: 4px 0 0; justify-content: center; }
+
+  .marketing-links {
+    background: linear-gradient(145deg, rgba(255,255,255,.72), rgba(255,255,255,.48));
+    border-color: rgba(255,255,255,.84);
+  }
+
+  .workspace-links {
+    background: rgba(10,14,21,.96);
+    border-color: var(--app-border);
+    box-shadow: 0 24px 70px rgba(0,0,0,.34);
+  }
+
+  .navbar-links.open {
+    display: grid;
+    gap: 4px;
+  }
+
+  .navbar-links a,
+  .nav-quiet-button {
+    width: 100%;
+    justify-content: flex-start;
+    min-height: 44px;
+  }
+
+  .navbar-links .nav-cta {
+    margin: 4px 0 0;
+    justify-content: center;
+  }
 }

--- a/frontend/src/components/NavBar/NavBar.scss
+++ b/frontend/src/components/NavBar/NavBar.scss
@@ -7,6 +7,8 @@
 }
 
 .navbar {
+  position: relative;
+  overflow: hidden;
   width: min(var(--container), calc(100vw - 32px));
   min-height: 58px;
   margin: 0 auto;
@@ -16,18 +18,29 @@
   justify-content: space-between;
   gap: 18px;
   border: 1px solid transparent;
-  border-radius: 18px;
-  backdrop-filter: blur(var(--glass-blur)) saturate(150%);
-  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(150%);
+  border-radius: 19px;
+  backdrop-filter: blur(28px) saturate(180%);
+  -webkit-backdrop-filter: blur(28px) saturate(180%);
   pointer-events: auto;
-  transition: background var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base);
+  transition: background var(--transition-base), border-color var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast);
 }
+
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(115deg, rgba(255,255,255,.26), transparent 28%, transparent 72%, rgba(255,255,255,.08));
+  opacity: .7;
+}
+
+.navbar > * { position: relative; z-index: 1; }
 
 .marketing-navbar {
   color: var(--marketing-text);
-  background: rgba(248, 248, 246, 0.78);
-  border-color: rgba(17, 19, 23, 0.08);
-  box-shadow: 0 12px 32px rgba(16, 24, 40, 0.07);
+  background: linear-gradient(145deg, rgba(255,255,255,.58), rgba(248,248,246,.34));
+  border-color: rgba(255,255,255,.76);
+  box-shadow: 0 18px 46px rgba(16,24,40,.09), inset 0 1px 0 rgba(255,255,255,.92);
 }
 
 .workspace-navbar {
@@ -53,10 +66,11 @@
   height: 34px;
   display: grid;
   place-items: center;
+  border: 1px solid rgba(255,255,255,.34);
   border-radius: 11px;
   color: #fff;
-  background: linear-gradient(145deg, var(--brand-500), #3b82f6);
-  box-shadow: 0 8px 24px rgba(91, 92, 240, 0.28);
+  background: linear-gradient(145deg, rgba(111,108,246,.96), rgba(59,130,246,.92));
+  box-shadow: 0 8px 24px rgba(91, 92, 240, 0.28), inset 0 1px 0 rgba(255,255,255,.23);
 }
 
 .brand-wordmark { font-size: 1rem; }
@@ -87,12 +101,16 @@
   text-decoration: none;
   font-size: .82rem;
   font-weight: 650;
-  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+  transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .marketing-links a:not(.nav-cta) { color: #4b5563; }
 .marketing-links a:not(.nav-cta):hover,
-.marketing-links a.active { color: #111317; background: rgba(17, 19, 23, 0.05); }
+.marketing-links a.active {
+  color: #111317;
+  background: rgba(255,255,255,.46);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.72);
+}
 
 .workspace-links a,
 .workspace-links .nav-quiet-button { color: #aab3c2; }
@@ -104,8 +122,10 @@
   margin-left: 4px;
   padding-inline: 15px;
   color: #fff;
-  background: #111317;
-  box-shadow: 0 8px 20px rgba(17, 19, 23, 0.16);
+  border: 1px solid rgba(255,255,255,.16);
+  background: rgba(17,19,23,.92);
+  box-shadow: 0 10px 24px rgba(17, 19, 23, 0.16), inset 0 1px 0 rgba(255,255,255,.12);
+  backdrop-filter: blur(10px);
 }
 
 .navbar-links .nav-cta:hover { transform: translateY(-1px); background: #000; }
@@ -120,6 +140,10 @@
   border-radius: 11px;
   background: transparent;
   color: inherit;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .marketing-navbar { backdrop-filter: none; -webkit-backdrop-filter: none; background: rgba(248,248,246,.96); }
 }
 
 @media (max-width: 820px) {
@@ -137,9 +161,10 @@
     border: 1px solid transparent;
     border-radius: 16px;
     box-shadow: var(--shadow-md);
-    backdrop-filter: blur(var(--glass-blur)) saturate(160%);
+    backdrop-filter: blur(28px) saturate(180%);
+    -webkit-backdrop-filter: blur(28px) saturate(180%);
   }
-  .marketing-links { background: rgba(248,248,246,.96); border-color: rgba(17,19,23,.08); }
+  .marketing-links { background: rgba(255,255,255,.66); border-color: rgba(255,255,255,.82); }
   .workspace-links { background: rgba(10,14,21,.96); border-color: var(--app-border); }
   .navbar-links.open { display: grid; }
   .navbar-links a, .nav-quiet-button { width: 100%; justify-content: flex-start; min-height: 44px; }

--- a/frontend/src/components/NavBar/NavBar.test.js
+++ b/frontend/src/components/NavBar/NavBar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import useAuthStore from '../../stores/authStore';
 import NavBar from './NavBar';
@@ -20,6 +20,26 @@ test('renders website navigation on public routes', () => {
   expect(screen.getByRole('navigation', { name: /website navigation/i })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: /sign in/i })).toHaveAttribute('href', '/login');
   expect(screen.getByRole('link', { name: /get started/i })).toHaveAttribute('href', '/register');
+});
+
+test('toggles the website mobile navigation from the burger button', () => {
+  renderAt('/');
+
+  const toggle = screen.getByRole('button', { name: /toggle website navigation/i });
+  const links = screen.getByRole('link', { name: /features/i }).closest('.navbar-links');
+
+  expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  expect(links).not.toHaveClass('open');
+
+  fireEvent.click(toggle);
+
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  expect(links).toHaveClass('open');
+
+  fireEvent.click(toggle);
+
+  expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  expect(links).not.toHaveClass('open');
 });
 
 test('offers the workspace from the website when authenticated', () => {

--- a/frontend/src/features/Home/HomePage.js
+++ b/frontend/src/features/Home/HomePage.js
@@ -99,7 +99,7 @@ const HomePage = () => {
       <footer className="marketing-footer">
         <div className="marketing-container footer-layout">
           <div className="footer-brand"><span className="preview-mini-brand">F</span><div><strong>Festivio</strong><p>Event planning and team coordination.</p></div></div>
-          <div className="footer-links"><a href="#features">Features</a><a href="#workflow">How it works</a><Link to="/services">Platform</Link>{accessToken ? <Link to="/home">Workspace</Link> : <Link to="/login">Sign in</Link>}</div>
+          <div className="footer-links"><a href="#features">Features</a><a href="#workflow">How it works</a>{accessToken ? <Link to="/home">Workspace</Link> : <Link to="/login">Sign in</Link>}</div>
           <p>© {new Date().getFullYear()} Festivio. Open-source software.</p>
         </div>
       </footer>

--- a/frontend/src/features/Services/ServicesPage.scss
+++ b/frontend/src/features/Services/ServicesPage.scss
@@ -3,9 +3,10 @@
   padding-top: var(--header-height);
   color: var(--marketing-text);
   background:
-    radial-gradient(circle at 16% 7%, rgba(126, 123, 255, .12), transparent 28%),
-    radial-gradient(circle at 88% 9%, rgba(83, 166, 255, .1), transparent 26%),
-    var(--marketing-bg);
+    radial-gradient(circle at 14% 7%, rgba(126, 123, 255, .19), transparent 27%),
+    radial-gradient(circle at 88% 10%, rgba(83, 166, 255, .16), transparent 27%),
+    radial-gradient(circle at 54% 78%, rgba(197, 154, 255, .1), transparent 31%),
+    linear-gradient(145deg, #f7f7f3 0%, #f1f3f8 50%, #f6f5f2 100%);
 }
 
 .platform-hero {
@@ -41,18 +42,36 @@
 }
 
 .role-grid article {
+  position: relative;
+  overflow: hidden;
   padding: 30px;
-  border: 1px solid var(--marketing-border);
-  border-radius: 24px;
-  background: rgba(255, 255, 255, .66);
-  box-shadow: var(--shadow-sm);
-  backdrop-filter: blur(14px);
-  transition: transform var(--transition-base), box-shadow var(--transition-base);
+  border: 1px solid rgba(255,255,255,.76);
+  border-radius: 26px;
+  background: linear-gradient(145deg, rgba(255,255,255,.58), rgba(255,255,255,.3));
+  box-shadow: 0 20px 54px rgba(31,38,54,.08), inset 0 1px 0 rgba(255,255,255,.9);
+  backdrop-filter: blur(26px) saturate(175%);
+  -webkit-backdrop-filter: blur(26px) saturate(175%);
+  transition: transform var(--transition-base), box-shadow var(--transition-base), border-color var(--transition-base);
+}
+
+.role-grid article::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(255,255,255,.36), transparent 28%, transparent 74%, rgba(255,255,255,.11));
+  opacity: .75;
+}
+
+.role-grid article > * {
+  position: relative;
+  z-index: 1;
 }
 
 .role-grid article:hover {
-  transform: translateY(-3px);
-  box-shadow: var(--shadow-md);
+  transform: translateY(-5px);
+  border-color: rgba(255,255,255,.95);
+  box-shadow: 0 28px 68px rgba(31,38,54,.12), inset 0 1px 0 rgba(255,255,255,.98);
 }
 
 .role-grid article > span {
@@ -60,9 +79,12 @@
   height: 44px;
   display: grid;
   place-items: center;
+  border: 1px solid rgba(255,255,255,.72);
   border-radius: 14px;
   color: #fff;
-  background: #111317;
+  background: rgba(17,19,23,.92);
+  box-shadow: 0 10px 24px rgba(17,19,23,.13), inset 0 1px 0 rgba(255,255,255,.13);
+  backdrop-filter: blur(10px);
 }
 
 .role-grid h2 {
@@ -83,16 +105,32 @@
 }
 
 .platform-cta .marketing-container {
+  position: relative;
+  overflow: hidden;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 34px;
   padding: 42px;
-  border: 1px solid var(--marketing-border);
-  border-radius: 28px;
-  background: rgba(255,255,255,.74);
-  box-shadow: var(--shadow-md);
-  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255,255,255,.8);
+  border-radius: 30px;
+  background: linear-gradient(145deg, rgba(255,255,255,.62), rgba(255,255,255,.34));
+  box-shadow: 0 26px 70px rgba(31,38,54,.1), inset 0 1px 0 rgba(255,255,255,.96);
+  backdrop-filter: blur(30px) saturate(180%);
+  -webkit-backdrop-filter: blur(30px) saturate(180%);
+}
+
+.platform-cta .marketing-container::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 0%, rgba(255,255,255,.65), transparent 36%), linear-gradient(120deg, rgba(255,255,255,.32), transparent 30%, transparent 78%, rgba(255,255,255,.1));
+}
+
+.platform-cta .marketing-container > * {
+  position: relative;
+  z-index: 1;
 }
 
 .platform-cta h2 {
@@ -110,12 +148,22 @@
 .platform-cta .primary-button {
   flex: 0 0 auto;
   color: #fff;
-  background: #111317;
-  box-shadow: 0 14px 34px rgba(17,19,23,.14);
+  border: 1px solid rgba(255,255,255,.18);
+  background: rgba(17,19,23,.94);
+  box-shadow: 0 14px 34px rgba(17,19,23,.15), inset 0 1px 0 rgba(255,255,255,.14);
 }
 
 .platform-cta .primary-button:hover {
   background: #000;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .role-grid article,
+  .platform-cta .marketing-container {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(255,255,255,.92);
+  }
 }
 
 @media(max-width:700px){

--- a/frontend/src/features/Services/ServicesPage.scss
+++ b/frontend/src/features/Services/ServicesPage.scss
@@ -1,1 +1,126 @@
-.platform-page { min-height: 100vh; padding-top: 72px; color: #e8edf7; background: #070c18; }.platform-hero { padding: 110px 0 72px; text-align: center; background: radial-gradient(circle at 50% 0,rgba(99,102,241,.17),transparent 44%); }.platform-hero .marketing-container { max-width: 780px; }.platform-hero h1 { margin: 8px 0 18px; font-size: clamp(2.7rem,6vw,5rem); letter-spacing: -.055em; }.platform-hero p { color: #98a5b9; line-height: 1.75; }.role-grid { display: grid; grid-template-columns: repeat(2,1fr); gap: 16px; padding-bottom: 100px; }.role-grid article { padding: 32px; border-radius: 22px; border: 1px solid rgba(148,163,184,.13); background: #0c1424; }.role-grid article > span { width: 44px; height: 44px; display: grid; place-items: center; color: #c7d2fe; background: rgba(99,102,241,.13); border-radius: 14px; }.role-grid h2 { margin: 20px 0 10px; font-size: 1.25rem; }.role-grid p { margin: 0; color: #8794a8; line-height: 1.7; }.platform-cta { padding: 60px 0; border-top: 1px solid rgba(148,163,184,.1); background: #0a101d; }.platform-cta .marketing-container { display: flex; justify-content: space-between; align-items: center; gap: 30px; }.platform-cta h2 { margin: 0 0 8px; font-size: 2rem; }.platform-cta p { margin: 0; color: #8794a8; }@media(max-width:700px){.role-grid{grid-template-columns:1fr}.platform-cta .marketing-container{align-items:flex-start;flex-direction:column}}
+.platform-page {
+  min-height: 100vh;
+  padding-top: var(--header-height);
+  color: var(--marketing-text);
+  background:
+    radial-gradient(circle at 16% 7%, rgba(126, 123, 255, .12), transparent 28%),
+    radial-gradient(circle at 88% 9%, rgba(83, 166, 255, .1), transparent 26%),
+    var(--marketing-bg);
+}
+
+.platform-hero {
+  padding: 104px 0 66px;
+  text-align: center;
+}
+
+.platform-hero .marketing-container {
+  max-width: 790px;
+}
+
+.platform-hero h1 {
+  margin: 12px 0 18px;
+  font-family: var(--font-display);
+  font-size: clamp(3rem, 6vw, 5.4rem);
+  line-height: .98;
+  letter-spacing: -.065em;
+  font-weight: 660;
+}
+
+.platform-hero p:last-child {
+  margin: 0 auto;
+  max-width: 680px;
+  color: var(--marketing-muted);
+  line-height: 1.75;
+}
+
+.role-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  padding-bottom: 92px;
+}
+
+.role-grid article {
+  padding: 30px;
+  border: 1px solid var(--marketing-border);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, .66);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: blur(14px);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.role-grid article:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-md);
+}
+
+.role-grid article > span {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  color: #fff;
+  background: #111317;
+}
+
+.role-grid h2 {
+  margin: 22px 0 10px;
+  color: #17191d;
+  font-size: 1.14rem;
+  letter-spacing: -.025em;
+}
+
+.role-grid p {
+  margin: 0;
+  color: var(--marketing-muted);
+  line-height: 1.72;
+}
+
+.platform-cta {
+  padding: 34px 0 92px;
+}
+
+.platform-cta .marketing-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 34px;
+  padding: 42px;
+  border: 1px solid var(--marketing-border);
+  border-radius: 28px;
+  background: rgba(255,255,255,.74);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(16px);
+}
+
+.platform-cta h2 {
+  margin: 0 0 8px;
+  color: #111317;
+  font-size: clamp(1.8rem, 3vw, 2.8rem);
+  letter-spacing: -.045em;
+}
+
+.platform-cta p {
+  margin: 0;
+  color: var(--marketing-muted);
+}
+
+.platform-cta .primary-button {
+  flex: 0 0 auto;
+  color: #fff;
+  background: #111317;
+  box-shadow: 0 14px 34px rgba(17,19,23,.14);
+}
+
+.platform-cta .primary-button:hover {
+  background: #000;
+}
+
+@media(max-width:700px){
+  .platform-hero { padding-top: 82px; }
+  .role-grid{grid-template-columns:1fr}
+  .platform-cta .marketing-container{align-items:flex-start;flex-direction:column;padding:30px 24px}
+  .platform-cta .primary-button{width:100%}
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './styles/tokens.css';
 import './index.css';
+import './styles/public.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './styles/tokens.css';
 import './index.css';
 import './styles/public.css';
+import './styles/glass.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/frontend/src/styles/glass.css
+++ b/frontend/src/styles/glass.css
@@ -1,34 +1,37 @@
-.marketing-page {
+.marketing-page,
+.platform-page,
+.auth-shell,
+.app-loading {
   background:
-    radial-gradient(circle at 12% 8%, rgba(126, 123, 255, .2), transparent 29%),
-    radial-gradient(circle at 89% 12%, rgba(83, 166, 255, .17), transparent 28%),
-    radial-gradient(circle at 54% 84%, rgba(194, 155, 255, .09), transparent 31%),
-    linear-gradient(145deg, #f7f7f3 0%, #f1f3f8 50%, #f6f5f2 100%);
+    radial-gradient(circle at 10% 7%, rgba(126, 123, 255, .24), transparent 29%),
+    radial-gradient(circle at 90% 12%, rgba(83, 166, 255, .21), transparent 28%),
+    radial-gradient(circle at 54% 84%, rgba(194, 155, 255, .13), transparent 31%),
+    linear-gradient(145deg, #f7f7f3 0%, #eef1f7 48%, #f6f5f2 100%) !important;
 }
 
 .hero-badge {
-  border-color: rgba(255,255,255,.78) !important;
-  background: linear-gradient(145deg, rgba(255,255,255,.58), rgba(255,255,255,.32)) !important;
-  box-shadow: 0 12px 32px rgba(31,38,54,.08), inset 0 1px 0 rgba(255,255,255,.92) !important;
-  backdrop-filter: blur(22px) saturate(175%);
-  -webkit-backdrop-filter: blur(22px) saturate(175%);
+  border-color: rgba(255,255,255,.72) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.4), rgba(255,255,255,.16)) !important;
+  box-shadow: 0 12px 32px rgba(31,38,54,.075), inset 0 1px 0 rgba(255,255,255,.88) !important;
+  backdrop-filter: blur(28px) saturate(190%);
+  -webkit-backdrop-filter: blur(28px) saturate(190%);
 }
 
 .marketing-secondary {
-  border-color: rgba(255,255,255,.78) !important;
-  background: rgba(255,255,255,.42) !important;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.82), 0 8px 24px rgba(31,38,54,.05);
-  backdrop-filter: blur(18px) saturate(165%);
-  -webkit-backdrop-filter: blur(18px) saturate(165%);
+  border-color: rgba(255,255,255,.7) !important;
+  background: rgba(255,255,255,.28) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.78), 0 8px 24px rgba(31,38,54,.05);
+  backdrop-filter: blur(24px) saturate(185%);
+  -webkit-backdrop-filter: blur(24px) saturate(185%);
 }
 
 .product-preview {
   position: relative;
-  border-color: rgba(255,255,255,.8) !important;
-  background: linear-gradient(145deg, rgba(255,255,255,.58), rgba(255,255,255,.3)) !important;
-  box-shadow: 0 38px 110px rgba(31,38,54,.16), inset 0 1px 0 rgba(255,255,255,.96) !important;
-  backdrop-filter: blur(34px) saturate(185%) !important;
-  -webkit-backdrop-filter: blur(34px) saturate(185%) !important;
+  border-color: rgba(255,255,255,.74) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.4), rgba(255,255,255,.14)) !important;
+  box-shadow: 0 38px 110px rgba(31,38,54,.14), inset 0 1px 0 rgba(255,255,255,.93) !important;
+  backdrop-filter: blur(42px) saturate(195%) !important;
+  -webkit-backdrop-filter: blur(42px) saturate(195%) !important;
 }
 
 .product-preview::before {
@@ -38,8 +41,8 @@
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 18% 0%, rgba(255,255,255,.7), transparent 31%),
-    linear-gradient(120deg, rgba(255,255,255,.28), transparent 30%, transparent 76%, rgba(255,255,255,.1));
+    radial-gradient(circle at 18% 0%, rgba(255,255,255,.56), transparent 31%),
+    linear-gradient(120deg, rgba(255,255,255,.2), transparent 30%, transparent 76%, rgba(255,255,255,.07));
 }
 
 .product-preview > * { position: relative; z-index: 1; }
@@ -49,21 +52,21 @@
 .preview-content,
 .preview-stats article,
 .preview-panel {
-  border-color: rgba(255,255,255,.64) !important;
-  background: rgba(255,255,255,.38) !important;
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.78);
-  backdrop-filter: blur(16px) saturate(155%);
-  -webkit-backdrop-filter: blur(16px) saturate(155%);
+  border-color: rgba(255,255,255,.56) !important;
+  background: rgba(255,255,255,.24) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.72);
+  backdrop-filter: blur(22px) saturate(175%);
+  -webkit-backdrop-filter: blur(22px) saturate(175%);
 }
 
 .feature-grid article {
   position: relative;
   overflow: hidden;
-  border-color: rgba(255,255,255,.78) !important;
-  background: linear-gradient(145deg, rgba(255,255,255,.55), rgba(255,255,255,.29)) !important;
-  box-shadow: 0 20px 52px rgba(31,38,54,.075), inset 0 1px 0 rgba(255,255,255,.92) !important;
-  backdrop-filter: blur(26px) saturate(175%) !important;
-  -webkit-backdrop-filter: blur(26px) saturate(175%) !important;
+  border-color: rgba(255,255,255,.72) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.38), rgba(255,255,255,.13)) !important;
+  box-shadow: 0 20px 52px rgba(31,38,54,.07), inset 0 1px 0 rgba(255,255,255,.88) !important;
+  backdrop-filter: blur(34px) saturate(190%) !important;
+  -webkit-backdrop-filter: blur(34px) saturate(190%) !important;
 }
 
 .feature-grid article::before {
@@ -71,31 +74,31 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(120deg, rgba(255,255,255,.34), transparent 27%, transparent 75%, rgba(255,255,255,.1));
+  background: linear-gradient(120deg, rgba(255,255,255,.26), transparent 27%, transparent 75%, rgba(255,255,255,.06));
 }
 
 .feature-grid article > * { position: relative; z-index: 1; }
-.feature-grid article:hover { box-shadow: 0 30px 68px rgba(31,38,54,.12), inset 0 1px 0 rgba(255,255,255,.98) !important; }
+.feature-grid article:hover { box-shadow: 0 30px 68px rgba(31,38,54,.11), inset 0 1px 0 rgba(255,255,255,.94) !important; }
 
 .feature-icon {
   border: 1px solid rgba(255,255,255,.18);
-  background: rgba(17,19,23,.92) !important;
+  background: rgba(17,19,23,.9) !important;
   box-shadow: 0 10px 24px rgba(17,19,23,.13), inset 0 1px 0 rgba(255,255,255,.12);
-  backdrop-filter: blur(10px);
+  backdrop-filter: blur(12px);
 }
 
 .workflow-steps article {
-  border-top-color: rgba(255,255,255,.7) !important;
+  border-top-color: rgba(255,255,255,.62) !important;
 }
 
 .cta-card {
   position: relative;
   overflow: hidden;
-  border-color: rgba(255,255,255,.82) !important;
-  background: linear-gradient(145deg, rgba(255,255,255,.6), rgba(255,255,255,.32)) !important;
-  box-shadow: 0 28px 78px rgba(31,38,54,.11), inset 0 1px 0 rgba(255,255,255,.96) !important;
-  backdrop-filter: blur(30px) saturate(180%);
-  -webkit-backdrop-filter: blur(30px) saturate(180%);
+  border-color: rgba(255,255,255,.76) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.42), rgba(255,255,255,.15)) !important;
+  box-shadow: 0 28px 78px rgba(31,38,54,.1), inset 0 1px 0 rgba(255,255,255,.92) !important;
+  backdrop-filter: blur(38px) saturate(195%);
+  -webkit-backdrop-filter: blur(38px) saturate(195%);
 }
 
 .cta-card::before {
@@ -103,19 +106,179 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(circle at 18% 0%, rgba(255,255,255,.66), transparent 34%), linear-gradient(120deg, rgba(255,255,255,.3), transparent 28%, transparent 78%, rgba(255,255,255,.1));
+  background: radial-gradient(circle at 18% 0%, rgba(255,255,255,.5), transparent 34%), linear-gradient(120deg, rgba(255,255,255,.2), transparent 28%, transparent 78%, rgba(255,255,255,.06));
 }
 
 .cta-card > * { position: relative; z-index: 1; }
+
+.auth-shell {
+  color: #111317 !important;
+}
+
+.auth-card {
+  border-color: rgba(255,255,255,.74) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.36), rgba(255,255,255,.12)) !important;
+  box-shadow: 0 30px 86px rgba(31,38,54,.12), inset 0 1px 0 rgba(255,255,255,.92) !important;
+  backdrop-filter: blur(42px) saturate(200%) !important;
+  -webkit-backdrop-filter: blur(42px) saturate(200%) !important;
+}
+
+.auth-card::before {
+  opacity: .54 !important;
+}
+
+.auth-form input,
+.auth-form select {
+  border-color: rgba(255,255,255,.68) !important;
+  background: rgba(255,255,255,.24) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.82), 0 6px 18px rgba(31,38,54,.035) !important;
+  backdrop-filter: blur(20px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(20px) saturate(180%) !important;
+}
+
+.auth-form input:focus,
+.auth-form select:focus {
+  background: rgba(255,255,255,.4) !important;
+  border-color: rgba(111,108,246,.44) !important;
+  box-shadow: 0 0 0 4px rgba(111,108,246,.075), inset 0 1px 0 rgba(255,255,255,.9), 0 10px 24px rgba(31,38,54,.05) !important;
+}
+
+.auth-alert-error,
+.auth-alert-success {
+  background: rgba(255,255,255,.3) !important;
+  border-color: rgba(255,255,255,.66) !important;
+  backdrop-filter: blur(24px) saturate(180%) !important;
+  -webkit-backdrop-filter: blur(24px) saturate(180%) !important;
+}
+
+.platform-page .role-grid article {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(255,255,255,.72) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.36), rgba(255,255,255,.12)) !important;
+  box-shadow: 0 20px 56px rgba(31,38,54,.075), inset 0 1px 0 rgba(255,255,255,.9) !important;
+  backdrop-filter: blur(34px) saturate(190%) !important;
+  -webkit-backdrop-filter: blur(34px) saturate(190%) !important;
+}
+
+.platform-page .role-grid article::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(255,255,255,.23), transparent 28%, transparent 75%, rgba(255,255,255,.06));
+}
+
+.platform-page .role-grid article > * {
+  position: relative;
+  z-index: 1;
+}
+
+.platform-page .platform-cta .marketing-container {
+  border-color: rgba(255,255,255,.74) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.38), rgba(255,255,255,.12)) !important;
+  box-shadow: 0 28px 76px rgba(31,38,54,.09), inset 0 1px 0 rgba(255,255,255,.9) !important;
+  backdrop-filter: blur(36px) saturate(190%) !important;
+  -webkit-backdrop-filter: blur(36px) saturate(190%) !important;
+}
+
+.app-loading {
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  color: #5f6672 !important;
+  gap: 14px !important;
+  overflow: hidden;
+  font-size: .82rem;
+  font-weight: 650;
+  letter-spacing: -.01em;
+}
+
+.app-loading::before,
+.app-loading::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  border-radius: 50%;
+  filter: blur(92px);
+  pointer-events: none;
+}
+
+.app-loading::before {
+  width: 380px;
+  height: 380px;
+  left: -100px;
+  top: 18%;
+  background: rgba(111,108,246,.22);
+}
+
+.app-loading::after {
+  width: 430px;
+  height: 430px;
+  right: -140px;
+  bottom: 8%;
+  background: rgba(73,150,255,.18);
+}
+
+.app-loading-mark {
+  position: relative;
+  width: 48px !important;
+  height: 48px !important;
+  border: 1px solid rgba(255,255,255,.76);
+  border-radius: 16px !important;
+  color: #fff !important;
+  background: linear-gradient(145deg, rgba(111,108,246,.88), rgba(59,130,246,.82)) !important;
+  box-shadow: 0 18px 42px rgba(79,70,229,.2), inset 0 1px 0 rgba(255,255,255,.34) !important;
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  animation: festivio-loader-float 1.8s ease-in-out infinite;
+}
+
+.app-loading-mark::after {
+  content: '';
+  position: absolute;
+  inset: -7px;
+  border: 1px solid rgba(111,108,246,.18);
+  border-top-color: rgba(111,108,246,.58);
+  border-radius: 20px;
+  animation: festivio-loader-spin 1.4s linear infinite;
+}
+
+@keyframes festivio-loader-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes festivio-loader-float {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-loading-mark,
+  .app-loading-mark::after {
+    animation: none;
+  }
+}
 
 @media (prefers-reduced-transparency: reduce) {
   .hero-badge,
   .marketing-secondary,
   .product-preview,
   .feature-grid article,
-  .cta-card {
+  .cta-card,
+  .auth-card,
+  .auth-form input,
+  .auth-form select,
+  .platform-page .role-grid article,
+  .platform-page .platform-cta .marketing-container,
+  .app-loading-mark {
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
     background: rgba(255,255,255,.9) !important;
+  }
+
+  .app-loading-mark {
+    color: #fff !important;
+    background: linear-gradient(145deg, #6f6cf6, #3b82f6) !important;
   }
 }

--- a/frontend/src/styles/glass.css
+++ b/frontend/src/styles/glass.css
@@ -1,0 +1,121 @@
+.marketing-page {
+  background:
+    radial-gradient(circle at 12% 8%, rgba(126, 123, 255, .2), transparent 29%),
+    radial-gradient(circle at 89% 12%, rgba(83, 166, 255, .17), transparent 28%),
+    radial-gradient(circle at 54% 84%, rgba(194, 155, 255, .09), transparent 31%),
+    linear-gradient(145deg, #f7f7f3 0%, #f1f3f8 50%, #f6f5f2 100%);
+}
+
+.hero-badge {
+  border-color: rgba(255,255,255,.78) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.58), rgba(255,255,255,.32)) !important;
+  box-shadow: 0 12px 32px rgba(31,38,54,.08), inset 0 1px 0 rgba(255,255,255,.92) !important;
+  backdrop-filter: blur(22px) saturate(175%);
+  -webkit-backdrop-filter: blur(22px) saturate(175%);
+}
+
+.marketing-secondary {
+  border-color: rgba(255,255,255,.78) !important;
+  background: rgba(255,255,255,.42) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.82), 0 8px 24px rgba(31,38,54,.05);
+  backdrop-filter: blur(18px) saturate(165%);
+  -webkit-backdrop-filter: blur(18px) saturate(165%);
+}
+
+.product-preview {
+  position: relative;
+  border-color: rgba(255,255,255,.8) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.58), rgba(255,255,255,.3)) !important;
+  box-shadow: 0 38px 110px rgba(31,38,54,.16), inset 0 1px 0 rgba(255,255,255,.96) !important;
+  backdrop-filter: blur(34px) saturate(185%) !important;
+  -webkit-backdrop-filter: blur(34px) saturate(185%) !important;
+}
+
+.product-preview::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(255,255,255,.7), transparent 31%),
+    linear-gradient(120deg, rgba(255,255,255,.28), transparent 30%, transparent 76%, rgba(255,255,255,.1));
+}
+
+.product-preview > * { position: relative; z-index: 1; }
+
+.preview-window-bar,
+.preview-sidebar,
+.preview-content,
+.preview-stats article,
+.preview-panel {
+  border-color: rgba(255,255,255,.64) !important;
+  background: rgba(255,255,255,.38) !important;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.78);
+  backdrop-filter: blur(16px) saturate(155%);
+  -webkit-backdrop-filter: blur(16px) saturate(155%);
+}
+
+.feature-grid article {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(255,255,255,.78) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.55), rgba(255,255,255,.29)) !important;
+  box-shadow: 0 20px 52px rgba(31,38,54,.075), inset 0 1px 0 rgba(255,255,255,.92) !important;
+  backdrop-filter: blur(26px) saturate(175%) !important;
+  -webkit-backdrop-filter: blur(26px) saturate(175%) !important;
+}
+
+.feature-grid article::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(255,255,255,.34), transparent 27%, transparent 75%, rgba(255,255,255,.1));
+}
+
+.feature-grid article > * { position: relative; z-index: 1; }
+.feature-grid article:hover { box-shadow: 0 30px 68px rgba(31,38,54,.12), inset 0 1px 0 rgba(255,255,255,.98) !important; }
+
+.feature-icon {
+  border: 1px solid rgba(255,255,255,.18);
+  background: rgba(17,19,23,.92) !important;
+  box-shadow: 0 10px 24px rgba(17,19,23,.13), inset 0 1px 0 rgba(255,255,255,.12);
+  backdrop-filter: blur(10px);
+}
+
+.workflow-steps article {
+  border-top-color: rgba(255,255,255,.7) !important;
+}
+
+.cta-card {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(255,255,255,.82) !important;
+  background: linear-gradient(145deg, rgba(255,255,255,.6), rgba(255,255,255,.32)) !important;
+  box-shadow: 0 28px 78px rgba(31,38,54,.11), inset 0 1px 0 rgba(255,255,255,.96) !important;
+  backdrop-filter: blur(30px) saturate(180%);
+  -webkit-backdrop-filter: blur(30px) saturate(180%);
+}
+
+.cta-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 18% 0%, rgba(255,255,255,.66), transparent 34%), linear-gradient(120deg, rgba(255,255,255,.3), transparent 28%, transparent 78%, rgba(255,255,255,.1));
+}
+
+.cta-card > * { position: relative; z-index: 1; }
+
+@media (prefers-reduced-transparency: reduce) {
+  .hero-badge,
+  .marketing-secondary,
+  .product-preview,
+  .feature-grid article,
+  .cta-card {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background: rgba(255,255,255,.9) !important;
+  }
+}

--- a/frontend/src/styles/public.css
+++ b/frontend/src/styles/public.css
@@ -1,0 +1,244 @@
+.marketing-page,
+.platform-page,
+.auth-shell {
+  color-scheme: light;
+}
+
+.auth-shell {
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  padding: 138px 20px 72px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  color: var(--marketing-text);
+  background:
+    radial-gradient(circle at 14% 10%, rgba(126, 123, 255, .14), transparent 30%),
+    radial-gradient(circle at 86% 14%, rgba(83, 166, 255, .12), transparent 28%),
+    var(--marketing-bg);
+}
+
+.auth-shell::before,
+.auth-shell::after {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  border-radius: 50%;
+  filter: blur(80px);
+  pointer-events: none;
+}
+
+.auth-shell::before {
+  width: 320px;
+  height: 320px;
+  left: -110px;
+  top: 24%;
+  background: rgba(111, 108, 246, .15);
+}
+
+.auth-shell::after {
+  width: 360px;
+  height: 360px;
+  right: -140px;
+  bottom: 8%;
+  background: rgba(73, 150, 255, .12);
+}
+
+.auth-card {
+  width: min(470px, 100%);
+  padding: 36px;
+  border: 1px solid var(--marketing-border);
+  border-radius: var(--radius-xl);
+  background: rgba(255, 255, 255, .72);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(var(--glass-blur)) saturate(145%);
+}
+
+.auth-card-wide {
+  width: min(720px, 100%);
+}
+
+.auth-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 30px;
+  color: #15181d;
+  font-size: .95rem;
+  font-weight: 800;
+  letter-spacing: -.025em;
+  text-decoration: none;
+}
+
+.auth-brand::before {
+  content: 'F';
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  color: #fff;
+  background: linear-gradient(145deg, var(--brand-500), #3b82f6);
+  box-shadow: 0 8px 22px rgba(79, 70, 229, .18);
+  font-size: .72rem;
+  font-weight: 850;
+}
+
+.auth-card .eyebrow {
+  color: #6664e8;
+}
+
+.auth-card h1 {
+  margin: 9px 0 10px;
+  color: #111317;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 2.65rem);
+  line-height: 1.05;
+  letter-spacing: -.055em;
+  font-weight: 650;
+}
+
+.auth-subtitle {
+  margin: 0;
+  color: var(--marketing-muted);
+  font-size: .88rem;
+  line-height: 1.7;
+}
+
+.auth-form {
+  display: grid;
+  gap: 17px;
+  margin-top: 28px;
+}
+
+.auth-form label {
+  display: grid;
+  gap: 7px;
+  color: #4e5663;
+  font-size: .75rem;
+  font-weight: 700;
+}
+
+.auth-form input,
+.auth-form select {
+  width: 100%;
+  min-height: 44px;
+  padding: 11px 12px;
+  border: 1px solid rgba(16, 24, 40, .11);
+  border-radius: 12px;
+  outline: none;
+  color: #16191e;
+  background: rgba(255, 255, 255, .8);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .55);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.auth-form input::placeholder {
+  color: #98a2b3;
+}
+
+.auth-form input:focus,
+.auth-form select:focus {
+  border-color: rgba(111, 108, 246, .6);
+  background: #fff;
+  box-shadow: 0 0 0 3px rgba(111, 108, 246, .1);
+}
+
+.auth-form select option {
+  color: #111317;
+  background: #fff;
+}
+
+.auth-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.auth-row {
+  display: flex;
+  justify-content: space-between;
+  color: #7b8290;
+  font-size: .75rem;
+}
+
+.auth-row a,
+.auth-footnote a {
+  color: #5553d8;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.auth-row a:hover,
+.auth-footnote a:hover {
+  color: #302eb3;
+}
+
+.auth-footnote {
+  margin: 21px 0 0;
+  color: #7b8290;
+  text-align: center;
+  font-size: .78rem;
+}
+
+.auth-shell .primary-button {
+  min-height: 44px;
+  color: #fff;
+  background: #111317;
+  box-shadow: 0 12px 30px rgba(17, 19, 23, .14);
+}
+
+.auth-shell .primary-button:hover {
+  background: #000;
+  box-shadow: 0 16px 34px rgba(17, 19, 23, .18);
+}
+
+.auth-alert {
+  margin-top: 18px;
+  padding: 11px 13px;
+  border-radius: 11px;
+  font-size: .78rem;
+}
+
+.auth-alert-error {
+  color: #b42318;
+  border: 1px solid rgba(240, 68, 56, .16);
+  background: rgba(254, 243, 242, .9);
+}
+
+.auth-alert-success {
+  color: #027a48;
+  border: 1px solid rgba(18, 183, 106, .16);
+  background: rgba(236, 253, 243, .9);
+}
+
+.auth-shell .checkbox-label {
+  color: #5f6672;
+}
+
+.auth-shell .checkbox-label input {
+  accent-color: var(--brand-600);
+}
+
+.private-shell {
+  color-scheme: dark;
+}
+
+@media (max-width: 650px) {
+  .auth-shell {
+    padding: 112px 14px 42px;
+  }
+
+  .auth-card {
+    padding: 28px 22px;
+    border-radius: 22px;
+  }
+
+  .auth-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/styles/public.css
+++ b/frontend/src/styles/public.css
@@ -2,6 +2,13 @@
 .platform-page,
 .auth-shell {
   color-scheme: light;
+  --public-glass: rgba(255, 255, 255, .48);
+  --public-glass-strong: rgba(255, 255, 255, .64);
+  --public-glass-soft: rgba(255, 255, 255, .34);
+  --public-glass-border: rgba(255, 255, 255, .72);
+  --public-glass-outline: rgba(16, 24, 40, .07);
+  --public-glass-shadow: 0 24px 70px rgba(31, 38, 54, .11), 0 3px 12px rgba(31, 38, 54, .05);
+  --public-glass-inset: inset 0 1px 0 rgba(255, 255, 255, .92), inset 0 -1px 0 rgba(255, 255, 255, .28);
 }
 
 .auth-shell {
@@ -14,9 +21,10 @@
   overflow: hidden;
   color: var(--marketing-text);
   background:
-    radial-gradient(circle at 14% 10%, rgba(126, 123, 255, .14), transparent 30%),
-    radial-gradient(circle at 86% 14%, rgba(83, 166, 255, .12), transparent 28%),
-    var(--marketing-bg);
+    radial-gradient(circle at 10% 8%, rgba(138, 135, 255, .23), transparent 29%),
+    radial-gradient(circle at 88% 15%, rgba(73, 150, 255, .19), transparent 29%),
+    radial-gradient(circle at 58% 90%, rgba(194, 155, 255, .12), transparent 31%),
+    linear-gradient(145deg, #f7f7f3 0%, #f1f3f8 48%, #f6f5f2 100%);
 }
 
 .auth-shell::before,
@@ -25,34 +33,55 @@
   position: absolute;
   z-index: -1;
   border-radius: 50%;
-  filter: blur(80px);
+  filter: blur(92px);
   pointer-events: none;
+  opacity: .95;
 }
 
 .auth-shell::before {
-  width: 320px;
-  height: 320px;
-  left: -110px;
-  top: 24%;
-  background: rgba(111, 108, 246, .15);
+  width: 390px;
+  height: 390px;
+  left: -115px;
+  top: 18%;
+  background: rgba(111, 108, 246, .22);
 }
 
 .auth-shell::after {
-  width: 360px;
-  height: 360px;
-  right: -140px;
-  bottom: 8%;
-  background: rgba(73, 150, 255, .12);
+  width: 430px;
+  height: 430px;
+  right: -155px;
+  bottom: 4%;
+  background: rgba(73, 150, 255, .18);
 }
 
 .auth-card {
+  position: relative;
+  overflow: hidden;
   width: min(470px, 100%);
   padding: 36px;
-  border: 1px solid var(--marketing-border);
-  border-radius: var(--radius-xl);
-  background: rgba(255, 255, 255, .72);
-  box-shadow: var(--shadow-md);
-  backdrop-filter: blur(var(--glass-blur)) saturate(145%);
+  border: 1px solid var(--public-glass-border);
+  border-radius: 30px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, .62), rgba(255, 255, 255, .32));
+  box-shadow: var(--public-glass-shadow), var(--public-glass-inset);
+  backdrop-filter: blur(34px) saturate(185%);
+  -webkit-backdrop-filter: blur(34px) saturate(185%);
+}
+
+.auth-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, rgba(255,255,255,.42), transparent 24%, transparent 74%, rgba(255,255,255,.16)),
+    radial-gradient(circle at 18% 0%, rgba(255,255,255,.75), transparent 34%);
+  opacity: .72;
+}
+
+.auth-card > * {
+  position: relative;
+  z-index: 1;
 }
 
 .auth-card-wide {
@@ -77,10 +106,11 @@
   height: 30px;
   display: grid;
   place-items: center;
+  border: 1px solid rgba(255,255,255,.72);
   border-radius: 10px;
   color: #fff;
-  background: linear-gradient(145deg, var(--brand-500), #3b82f6);
-  box-shadow: 0 8px 22px rgba(79, 70, 229, .18);
+  background: linear-gradient(145deg, rgba(111,108,246,.94), rgba(59,130,246,.92));
+  box-shadow: 0 10px 26px rgba(79, 70, 229, .22), inset 0 1px 0 rgba(255,255,255,.34);
   font-size: .72rem;
   font-weight: 850;
 }
@@ -123,29 +153,38 @@
 .auth-form input,
 .auth-form select {
   width: 100%;
-  min-height: 44px;
-  padding: 11px 12px;
-  border: 1px solid rgba(16, 24, 40, .11);
-  border-radius: 12px;
+  min-height: 46px;
+  padding: 11px 13px;
+  border: 1px solid rgba(255, 255, 255, .8);
+  border-radius: 13px;
   outline: none;
   color: #16191e;
-  background: rgba(255, 255, 255, .8);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .55);
+  background: rgba(255, 255, 255, .5);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, .9),
+    0 1px 0 rgba(16, 24, 40, .035);
+  backdrop-filter: blur(14px) saturate(145%);
+  -webkit-backdrop-filter: blur(14px) saturate(145%);
   transition:
     border-color var(--transition-fast),
     box-shadow var(--transition-fast),
-    background var(--transition-fast);
+    background var(--transition-fast),
+    transform var(--transition-fast);
 }
 
 .auth-form input::placeholder {
-  color: #98a2b3;
+  color: #8f98a6;
 }
 
 .auth-form input:focus,
 .auth-form select:focus {
-  border-color: rgba(111, 108, 246, .6);
-  background: #fff;
-  box-shadow: 0 0 0 3px rgba(111, 108, 246, .1);
+  border-color: rgba(111, 108, 246, .5);
+  background: rgba(255,255,255,.7);
+  box-shadow:
+    0 0 0 4px rgba(111, 108, 246, .09),
+    inset 0 1px 0 rgba(255,255,255,.95),
+    0 8px 22px rgba(69,76,94,.06);
+  transform: translateY(-1px);
 }
 
 .auth-form select option {
@@ -186,34 +225,42 @@
 }
 
 .auth-shell .primary-button {
-  min-height: 44px;
+  min-height: 46px;
   color: #fff;
-  background: #111317;
-  box-shadow: 0 12px 30px rgba(17, 19, 23, .14);
+  border: 1px solid rgba(255,255,255,.18);
+  background: rgba(17, 19, 23, .94);
+  box-shadow:
+    0 14px 32px rgba(17, 19, 23, .17),
+    inset 0 1px 0 rgba(255,255,255,.13);
+  backdrop-filter: blur(12px);
 }
 
 .auth-shell .primary-button:hover {
   background: #000;
-  box-shadow: 0 16px 34px rgba(17, 19, 23, .18);
+  box-shadow: 0 18px 38px rgba(17, 19, 23, .22), inset 0 1px 0 rgba(255,255,255,.16);
 }
 
 .auth-alert {
   margin-top: 18px;
   padding: 11px 13px;
-  border-radius: 11px;
+  border-radius: 12px;
   font-size: .78rem;
+  backdrop-filter: blur(16px) saturate(150%);
+  -webkit-backdrop-filter: blur(16px) saturate(150%);
 }
 
 .auth-alert-error {
   color: #b42318;
-  border: 1px solid rgba(240, 68, 56, .16);
-  background: rgba(254, 243, 242, .9);
+  border: 1px solid rgba(255,255,255,.68);
+  background: rgba(254, 243, 242, .62);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.72);
 }
 
 .auth-alert-success {
   color: #027a48;
-  border: 1px solid rgba(18, 183, 106, .16);
-  background: rgba(236, 253, 243, .9);
+  border: 1px solid rgba(255,255,255,.68);
+  background: rgba(236, 253, 243, .62);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.72);
 }
 
 .auth-shell .checkbox-label {
@@ -228,6 +275,17 @@
   color-scheme: dark;
 }
 
+@media (prefers-reduced-transparency: reduce) {
+  .auth-card,
+  .auth-form input,
+  .auth-form select,
+  .auth-alert {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: rgba(255,255,255,.9);
+  }
+}
+
 @media (max-width: 650px) {
   .auth-shell {
     padding: 112px 14px 42px;
@@ -235,7 +293,7 @@
 
   .auth-card {
     padding: 28px 22px;
-    border-radius: 22px;
+    border-radius: 24px;
   }
 
   .auth-grid {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "festivio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Role-aware event planning and operations platform",
   "scripts": {


### PR DESCRIPTION
## Summary

Promote the current `develop` branch to `master` after merging the public-site visual polish work.

Includes:
- unified public-site design across landing and auth flows
- stronger glassmorphism and transparency treatment
- refreshed Festivio loader
- Festivio browser title, favicon and manifest metadata
- removal of the redundant public `Platform` navigation link
- mobile burger navigation fix and regression coverage

## Validation

The changes were merged through PR #69 into `develop`. This PR is only the normal `develop` -> `master` promotion and does not introduce additional code changes.