### PR TITLE
feat(seed): add realistic demo data and branded emails

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -8,6 +8,10 @@ const ResetPasswordRequest = require('../models/ResetPasswordRequest');
 const UserDTO = require('../dtos/UserDTO');
 const { config } = require('../config/env');
 const { ROLES, PUBLIC_REGISTRATION_ROLES } = require('../constants/roles');
+const {
+  buildPasswordResetEmail,
+  buildVerificationEmail,
+} = require('../services/emailTemplates');
 
 const REFRESH_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -82,7 +86,7 @@ const createTransporter = () => {
   return null;
 };
 
-const sendEmail = async (to, subject, html) => {
+const sendEmail = async (to, subject, email) => {
   const transporter = createTransporter();
   if (!transporter) {
     if (config.isProduction) {
@@ -96,7 +100,8 @@ const sendEmail = async (to, subject, html) => {
     from: config.emailFrom,
     to,
     subject,
-    html,
+    html: email.html,
+    text: email.text,
   });
 };
 
@@ -151,7 +156,10 @@ exports.register = async (req, res) => {
     await sendEmail(
       normalizedEmail,
       'Verify your Festivio account',
-      `<p>Welcome to Festivio.</p><p><a href="${verificationLink}">Verify your email address</a>.</p>`
+      buildVerificationEmail({
+        firstName: user.firstName,
+        verificationLink,
+      })
     );
 
     return res.status(201).json({
@@ -287,7 +295,10 @@ exports.requestPasswordReset = async (req, res) => {
     await sendEmail(
       user.email,
       'Reset your Festivio password',
-      `<p>A password reset was requested for your Festivio account.</p><p><a href="${resetLink}">Reset your password</a>. This link expires in one hour.</p>`
+      buildPasswordResetEmail({
+        firstName: user.firstName,
+        resetLink,
+      })
     );
 
     return res.json(genericResponse);

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -4,11 +4,215 @@ const { config } = require('../config/env');
 const User = require('../models/User');
 const Event = require('../models/Event');
 const Task = require('../models/Task');
-const {
-  DEMO_USER_DEFINITIONS,
-  LEGACY_DEMO_EVENT_NAMES,
-  buildDemoEvents,
-} = require('./demoData');
+const { ROLES } = require('../constants/roles');
+
+const user = (key, firstName, lastName, role) => ({
+  key,
+  firstName,
+  lastName,
+  username: key,
+  email: `${key}@festivio.local`,
+  role,
+});
+
+const DEMO_USER_DEFINITIONS = [
+  user('admin', 'Ada', 'Martin', ROLES.ADMIN),
+  user('manager', 'Morgan', 'Lefevre', ROLES.ORGANIZER_ADMIN),
+  user('lea', 'Lea', 'Dubois', ROLES.ORGANIZER_ADMIN),
+  user('karim', 'Karim', 'Benali', ROLES.ORGANIZER_ADMIN),
+  user('organizer', 'Owen', 'Mercier', ROLES.ORGANIZER),
+  user('sofia', 'Sofia', 'Garcia', ROLES.ORGANIZER),
+  user('lucas', 'Lucas', 'Bernard', ROLES.ORGANIZER),
+  user('emma', 'Emma', 'Roux', ROLES.ORGANIZER),
+  user('noah', 'Noah', 'Laurent', ROLES.ORGANIZER),
+  user('participant', 'Pia', 'Robert', ROLES.PARTICIPANT),
+  user('camille', 'Camille', 'Moreau', ROLES.PARTICIPANT),
+  user('hugo', 'Hugo', 'Petit', ROLES.PARTICIPANT),
+  user('sarah', 'Sarah', 'Cohen', ROLES.PARTICIPANT),
+  user('mehdi', 'Mehdi', 'Alaoui', ROLES.PARTICIPANT),
+  user('lina', 'Lina', 'Fournier', ROLES.PARTICIPANT),
+  user('thomas', 'Thomas', 'Leroy', ROLES.PARTICIPANT),
+  user('ines', 'Ines', 'Martinez', ROLES.PARTICIPANT),
+  user('julien', 'Julien', 'Nguyen', ROLES.PARTICIPANT),
+];
+
+const LEGACY_DEMO_EVENT_NAMES = ['Festivio Community Meetup'];
+
+const relativeDate = (baseDate, days, hour = 18, minute = 0) => {
+  const date = new Date(baseDate);
+  date.setUTCDate(date.getUTCDate() + days);
+  date.setUTCHours(hour, minute, 0, 0);
+  return date;
+};
+
+const task = (title, description, status, assignedToKey) => ({
+  title,
+  description,
+  status,
+  assignedToKey,
+});
+
+const buildDemoEvents = (baseDate = new Date()) => [
+  {
+    name: 'Paris Product & Design Summit 2026',
+    description:
+      'A full-day conference for product managers, designers and engineering leaders. The agenda includes a keynote, practical tracks, customer research roundtables, hosted lunch and an evening networking reception.',
+    date: relativeDate(baseDate, 18, 8),
+    organizerKey: 'manager',
+    participantKeys: ['participant', 'camille', 'hugo', 'sarah', 'mehdi', 'lina'],
+    isOnline: false,
+    imagePath:
+      'https://images.unsplash.com/photo-1505373877841-8d25f7d46678?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Confirm keynote speaker arrival', 'Confirm arrival, hotel check-in, green room access and pre-stage briefing.', 'Completed', 'organizer'),
+      task('Finalize catering headcount', 'Send final guest count and dietary requirements to the caterer.', 'In Progress', 'sofia'),
+      task('Prepare attendee check-in stations', 'Prepare laptops, badge stock, backup lists and the speaker fast lane.', 'Pending', 'lucas'),
+      task('Run main-stage AV rehearsal', 'Test microphones, presentation switching, lighting and backup playback.', 'Pending', 'emma'),
+      task('Schedule attendee briefing email', 'Send arrival instructions, transport guidance and final agenda highlights.', 'In Progress', 'noah'),
+    ],
+  },
+  {
+    name: 'Remote Engineering Leadership Forum',
+    description:
+      'A live online forum for engineering managers and staff engineers covering incident leadership, architecture decisions, healthy on-call practices and career frameworks.',
+    date: relativeDate(baseDate, 7, 16),
+    organizerKey: 'karim',
+    participantKeys: ['participant', 'hugo', 'sarah', 'thomas', 'julien'],
+    isOnline: true,
+    zoomLink: 'https://zoom.us/j/00000000001',
+    imagePath:
+      'https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Collect final speaker decks', 'Collect files, verify media and keep local backups.', 'Completed', 'emma'),
+      task('Assign breakout rooms', 'Prepare balanced peer groups and moderator ownership.', 'In Progress', 'noah'),
+      task('Run streaming rehearsal', 'Validate screen sharing, recording, waiting room and backup host permissions.', 'Pending', 'lucas'),
+      task('Prepare Q&A moderation sheet', 'Prepare seeded questions, speaker ownership and timing guidance.', 'Pending', 'organizer'),
+    ],
+  },
+  {
+    name: 'Green Cities Community Night',
+    description:
+      'An evening event bringing together urban planners, climate startups, mobility teams and local associations for short talks, project booths and networking.',
+    date: relativeDate(baseDate, 32, 18),
+    organizerKey: 'lea',
+    participantKeys: ['camille', 'sarah', 'mehdi', 'lina', 'ines', 'julien'],
+    isOnline: false,
+    imagePath:
+      'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Confirm partner booths', 'Confirm table dimensions, power needs and arrival times.', 'In Progress', 'sofia'),
+      task('Prepare zero-waste catering plan', 'Review reusable serviceware, collection points and food donation options.', 'Pending', 'emma'),
+      task('Coordinate speaker mic checks', 'Schedule speaker arrival windows and sound checks.', 'Pending', 'lucas'),
+      task('Publish low-carbon access guide', 'Publish metro, cycling, walking and accessibility information.', 'Completed', 'noah'),
+    ],
+  },
+  {
+    name: 'Open Source Maintainers Meetup',
+    description:
+      'A focused meetup for maintainers and contributors comparing release workflows, contributor onboarding, vulnerability disclosure and sustainable project governance.',
+    date: relativeDate(baseDate, -12, 18),
+    organizerKey: 'karim',
+    participantKeys: ['participant', 'hugo', 'mehdi', 'thomas', 'julien'],
+    isOnline: false,
+    imagePath:
+      'https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Prepare contributor welcome desk', 'Set up badges, project stickers and first-contribution guides.', 'Completed', 'organizer'),
+      task('Capture lightning talk recordings', 'Record talks, label files and archive approved recordings.', 'Completed', 'lucas'),
+      task('Send post-event resource pack', 'Send presentations, project links and the feedback form.', 'Completed', 'emma'),
+      task('Review attendee feedback', 'Summarize recurring feedback and recommendations for the next edition.', 'In Progress', 'noah'),
+    ],
+  },
+  {
+    name: 'Indie Makers Demo Evening',
+    description:
+      'A fast-paced demo night where independent builders and early-stage founders present working products, receive audience questions and meet collaborators.',
+    date: relativeDate(baseDate, 45, 18),
+    organizerKey: 'manager',
+    participantKeys: ['participant', 'camille', 'hugo', 'lina', 'thomas', 'ines'],
+    isOnline: false,
+    imagePath:
+      'https://images.unsplash.com/photo-1511578314322-379afb476865?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Finalize demo order', 'Lock the demo order according to setup requirements.', 'In Progress', 'organizer'),
+      task('Validate adapter and laptop kit', 'Test HDMI, USB-C adapters, guest Wi-Fi and backup laptop.', 'Pending', 'lucas'),
+      task('Prepare founder check-in packs', 'Prepare badges, demo order cards and Wi-Fi instructions.', 'Pending', 'sofia'),
+      task('Test audience voting', 'Validate QR voting and prepare a manual fallback tally.', 'Pending', 'emma'),
+      task('Prepare social recap', 'Prepare the photo shot list and winner announcement assets.', 'Pending', 'noah'),
+    ],
+  },
+  {
+    name: 'Data & AI for Operations Workshop',
+    description:
+      'A practical online workshop for operations and platform teams exploring AI-assisted triage, knowledge retrieval, workflow orchestration, evaluation and human review.',
+    date: relativeDate(baseDate, 21, 13),
+    organizerKey: 'lea',
+    participantKeys: ['sarah', 'mehdi', 'lina', 'thomas', 'julien'],
+    isOnline: true,
+    zoomLink: 'https://zoom.us/j/00000000002',
+    imagePath:
+      'https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Publish preparation guide', 'Send environment requirements, sample data and pre-reading list.', 'Completed', 'emma'),
+      task('Validate exercise datasets', 'Run every workshop exercise against final synthetic datasets.', 'In Progress', 'organizer'),
+      task('Prepare facilitator rooms', 'Assign facilitators, timings and expected outputs.', 'Pending', 'noah'),
+      task('Test fallback conference setup', 'Validate backup host access and downloadable exercise files.', 'Pending', 'lucas'),
+    ],
+  },
+  {
+    name: 'Bright Futures Fundraising Gala',
+    description:
+      'A fundraising gala supporting digital inclusion programs, with a welcome reception, beneficiary stories, seated dinner, live auction and closing music set.',
+    date: relativeDate(baseDate, 68, 19),
+    organizerKey: 'lea',
+    participantKeys: ['camille', 'sarah', 'mehdi', 'lina', 'thomas', 'ines'],
+    isOnline: false,
+    imagePath:
+      'https://images.unsplash.com/photo-1507501336603-6e31db2be093?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Finalize donor seating plan', 'Reconcile table hosts, accessibility needs and late RSVP changes.', 'In Progress', 'sofia'),
+      task('Prepare live auction runbook', 'Document auction order, bidder capture and payment handoff.', 'Pending', 'organizer'),
+      task('Coordinate beneficiary speakers', 'Confirm transport, arrival, support and stage rehearsal.', 'Pending', 'emma'),
+      task('Validate payment stations', 'Test card readers, receipts and backup connectivity.', 'Pending', 'lucas'),
+      task('Prepare volunteer briefing packs', 'Prepare role cards, floor map and escalation contacts.', 'Pending', 'noah'),
+    ],
+  },
+  {
+    name: 'Customer Community Breakfast',
+    description:
+      'A small-format breakfast for customer success, product and community leaders using facilitated roundtables and a practical working session.',
+    date: relativeDate(baseDate, 3, 8),
+    organizerKey: 'karim',
+    participantKeys: ['participant', 'camille', 'sarah', 'thomas'],
+    isOnline: false,
+    imagePath:
+      'https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Confirm roundtable hosts', 'Match each topic with an experienced host and send the discussion guide.', 'Completed', 'organizer'),
+      task('Review breakfast order', 'Confirm coffee, pastries, fruit and dietary alternatives.', 'In Progress', 'sofia'),
+      task('Print working templates', 'Print experiment canvases and table signage.', 'Pending', 'emma'),
+      task('Prepare venue opening checklist', 'Document room setup, check-in and signage checks.', 'Pending', 'lucas'),
+    ],
+  },
+  {
+    name: 'Security Incident Tabletop Exercise',
+    description:
+      'A private online tabletop exercise simulating a credential leak, suspicious access and partial service degradation, followed by a structured retrospective.',
+    date: relativeDate(baseDate, 12, 14),
+    organizerKey: 'karim',
+    participantKeys: ['hugo', 'mehdi', 'thomas', 'julien'],
+    isOnline: true,
+    zoomLink: 'https://zoom.us/j/00000000003',
+    imagePath:
+      'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?auto=format&fit=crop&w=1400&q=80',
+    tasks: [
+      task('Validate incident timeline', 'Review scenario injects, decision points and dependencies.', 'Completed', 'organizer'),
+      task('Prepare observer template', 'Create a structured sheet covering detection, ownership and recovery.', 'In Progress', 'noah'),
+      task('Test private room access', 'Verify meeting access controls and backup host permissions.', 'Pending', 'lucas'),
+      task('Prepare retrospective action log', 'Create the action tracker with owner, severity and due date fields.', 'Pending', 'emma'),
+    ],
+  },
+];
 
 const seed = async () => {
   if (config.isProduction) {
@@ -30,13 +234,7 @@ const seed = async () => {
       const { key, ...profile } = definition;
       users[key] = await User.findOneAndUpdate(
         { email: profile.email },
-        {
-          $set: {
-            ...profile,
-            password,
-            isVerified: true,
-          },
-        },
+        { $set: { ...profile, password, isVerified: true } },
         { upsert: true, new: true, setDefaultsOnInsert: true }
       );
     }
@@ -50,14 +248,14 @@ const seed = async () => {
     const existingDemoEvents = await Event.find({
       name: { $in: demoEventNames },
     }).select('_id');
-
     const existingDemoEventIds = existingDemoEvents.map((event) => event._id);
+
     if (existingDemoEventIds.length > 0) {
       await Task.deleteMany({ event: { $in: existingDemoEventIds } });
     }
     await Event.deleteMany({ name: { $in: demoEventNames } });
 
-    const demoEmails = DEMO_USER_DEFINITIONS.map((user) => user.email);
+    const demoEmails = DEMO_USER_DEFINITIONS.map((demoUser) => demoUser.email);
     await User.updateMany(
       { email: { $in: demoEmails } },
       { $set: { events: [], tasks: [] } }
@@ -67,17 +265,11 @@ const seed = async () => {
 
     for (const definition of eventDefinitions) {
       const organizer = users[definition.organizerKey];
-      if (!organizer) {
-        throw new Error(
-          `Unknown organizer key "${definition.organizerKey}" for ${definition.name}`
-        );
-      }
+      if (!organizer) throw new Error(`Unknown organizer key ${definition.organizerKey}`);
 
       const participants = definition.participantKeys.map((key) => {
         const participant = users[key];
-        if (!participant) {
-          throw new Error(`Unknown participant key "${key}" for ${definition.name}`);
-        }
+        if (!participant) throw new Error(`Unknown participant key ${key}`);
         return participant;
       });
 
@@ -95,13 +287,9 @@ const seed = async () => {
       const taskIds = [];
       for (const taskDefinition of definition.tasks) {
         const assignee = users[taskDefinition.assignedToKey];
-        if (!assignee) {
-          throw new Error(
-            `Unknown assignee key "${taskDefinition.assignedToKey}" for ${taskDefinition.title}`
-          );
-        }
+        if (!assignee) throw new Error(`Unknown assignee key ${taskDefinition.assignedToKey}`);
 
-        const task = await Task.create({
+        const createdTask = await Task.create({
           title: taskDefinition.title,
           description: taskDefinition.description,
           status: taskDefinition.status,
@@ -110,12 +298,12 @@ const seed = async () => {
           createdBy: organizer._id,
         });
 
-        taskIds.push(task._id);
+        taskIds.push(createdTask._id);
         taskCount += 1;
 
         await User.updateOne(
           { _id: assignee._id },
-          { $addToSet: { tasks: task._id } }
+          { $addToSet: { tasks: createdTask._id } }
         );
       }
 
@@ -127,12 +315,10 @@ const seed = async () => {
         { $addToSet: { events: event._id } }
       );
 
-      if (participants.length > 0) {
-        await User.updateMany(
-          { _id: { $in: participants.map((participant) => participant._id) } },
-          { $addToSet: { events: event._id } }
-        );
-      }
+      await User.updateMany(
+        { _id: { $in: participants.map((participant) => participant._id) } },
+        { $addToSet: { events: event._id } }
+      );
     }
 
     console.info('Festivio realistic demo dataset seeded.');

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -15,7 +15,7 @@ const user = (key, firstName, lastName, role) => ({
   role,
 });
 
-const DEMO_USER_DEFINITIONS = [
+const demoUsers = [
   user('admin', 'Ada', 'Martin', ROLES.ADMIN),
   user('manager', 'Morgan', 'Lefevre', ROLES.ORGANIZER_ADMIN),
   user('lea', 'Lea', 'Dubois', ROLES.ORGANIZER_ADMIN),
@@ -36,183 +36,185 @@ const DEMO_USER_DEFINITIONS = [
   user('julien', 'Julien', 'Nguyen', ROLES.PARTICIPANT),
 ];
 
-const LEGACY_DEMO_EVENT_NAMES = ['Festivio Community Meetup'];
-
-const relativeDate = (baseDate, days, hour = 18, minute = 0) => {
+const addDays = (baseDate, days, hour = 18, minute = 0) => {
   const date = new Date(baseDate);
   date.setUTCDate(date.getUTCDate() + days);
   date.setUTCHours(hour, minute, 0, 0);
   return date;
 };
 
-const task = (title, description, status, assignedToKey) => ({
+const task = (title, status, assignedToKey) => ({
   title,
-  description,
   status,
   assignedToKey,
+  description: `${title}. Confirm owners, timing, risks and handoff notes so the event team can execute without ambiguity.`,
 });
 
-const buildDemoEvents = (baseDate = new Date()) => [
+const buildEvents = (baseDate = new Date()) => [
   {
     name: 'Paris Product & Design Summit 2026',
-    description:
-      'A full-day conference for product managers, designers and engineering leaders. The agenda includes a keynote, practical tracks, customer research roundtables, hosted lunch and an evening networking reception.',
-    date: relativeDate(baseDate, 18, 8),
+    description: 'A full-day conference for product managers, designers and engineering leaders with a keynote, practical tracks, customer research roundtables, hosted lunch and an evening networking reception.',
+    date: addDays(baseDate, 18, 8),
     organizerKey: 'manager',
     participantKeys: ['participant', 'camille', 'hugo', 'sarah', 'mehdi', 'lina'],
     isOnline: false,
-    imagePath:
-      'https://images.unsplash.com/photo-1505373877841-8d25f7d46678?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1505373877841-8d25f7d46678?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Confirm keynote speaker arrival', 'Confirm arrival, hotel check-in, green room access and pre-stage briefing.', 'Completed', 'organizer'),
-      task('Finalize catering headcount', 'Send final guest count and dietary requirements to the caterer.', 'In Progress', 'sofia'),
-      task('Prepare attendee check-in stations', 'Prepare laptops, badge stock, backup lists and the speaker fast lane.', 'Pending', 'lucas'),
-      task('Run main-stage AV rehearsal', 'Test microphones, presentation switching, lighting and backup playback.', 'Pending', 'emma'),
-      task('Schedule attendee briefing email', 'Send arrival instructions, transport guidance and final agenda highlights.', 'In Progress', 'noah'),
+      task('Confirm keynote speaker arrival', 'Completed', 'organizer'),
+      task('Finalize catering headcount and dietary notes', 'In Progress', 'sofia'),
+      task('Prepare attendee check-in stations', 'Pending', 'lucas'),
+      task('Run main-stage AV rehearsal', 'Pending', 'emma'),
+      task('Schedule final attendee briefing email', 'In Progress', 'noah'),
     ],
   },
   {
     name: 'Remote Engineering Leadership Forum',
-    description:
-      'A live online forum for engineering managers and staff engineers covering incident leadership, architecture decisions, healthy on-call practices and career frameworks.',
-    date: relativeDate(baseDate, 7, 16),
+    description: 'A live online forum for engineering managers and staff engineers covering incident leadership, architecture decisions, healthy on-call practices and career frameworks.',
+    date: addDays(baseDate, 7, 16),
     organizerKey: 'karim',
     participantKeys: ['participant', 'hugo', 'sarah', 'thomas', 'julien'],
     isOnline: true,
     zoomLink: 'https://zoom.us/j/00000000001',
-    imagePath:
-      'https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Collect final speaker decks', 'Collect files, verify media and keep local backups.', 'Completed', 'emma'),
-      task('Assign breakout rooms', 'Prepare balanced peer groups and moderator ownership.', 'In Progress', 'noah'),
-      task('Run streaming rehearsal', 'Validate screen sharing, recording, waiting room and backup host permissions.', 'Pending', 'lucas'),
-      task('Prepare Q&A moderation sheet', 'Prepare seeded questions, speaker ownership and timing guidance.', 'Pending', 'organizer'),
+      task('Collect final speaker slide decks', 'Completed', 'emma'),
+      task('Moderate breakout room assignments', 'In Progress', 'noah'),
+      task('Run streaming and recording rehearsal', 'Pending', 'lucas'),
+      task('Prepare live Q&A moderation sheet', 'Pending', 'organizer'),
     ],
   },
   {
     name: 'Green Cities Community Night',
-    description:
-      'An evening event bringing together urban planners, climate startups, mobility teams and local associations for short talks, project booths and networking.',
-    date: relativeDate(baseDate, 32, 18),
+    description: 'An evening event bringing together urban planners, climate startups, mobility teams and local associations for short talks, project booths and networking.',
+    date: addDays(baseDate, 32, 18),
     organizerKey: 'lea',
     participantKeys: ['camille', 'sarah', 'mehdi', 'lina', 'ines', 'julien'],
     isOnline: false,
-    imagePath:
-      'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Confirm partner booths', 'Confirm table dimensions, power needs and arrival times.', 'In Progress', 'sofia'),
-      task('Prepare zero-waste catering plan', 'Review reusable serviceware, collection points and food donation options.', 'Pending', 'emma'),
-      task('Coordinate speaker mic checks', 'Schedule speaker arrival windows and sound checks.', 'Pending', 'lucas'),
-      task('Publish low-carbon access guide', 'Publish metro, cycling, walking and accessibility information.', 'Completed', 'noah'),
+      task('Confirm community partner booths', 'In Progress', 'sofia'),
+      task('Prepare zero-waste catering plan', 'Pending', 'emma'),
+      task('Coordinate speaker arrival and mic checks', 'Pending', 'lucas'),
+      task('Publish neighborhood access guide', 'Completed', 'noah'),
     ],
   },
   {
     name: 'Open Source Maintainers Meetup',
-    description:
-      'A focused meetup for maintainers and contributors comparing release workflows, contributor onboarding, vulnerability disclosure and sustainable project governance.',
-    date: relativeDate(baseDate, -12, 18),
+    description: 'A focused meetup for maintainers and contributors comparing release workflows, contributor onboarding, vulnerability disclosure and sustainable project governance.',
+    date: addDays(baseDate, -12, 18),
     organizerKey: 'karim',
     participantKeys: ['participant', 'hugo', 'mehdi', 'thomas', 'julien'],
     isOnline: false,
-    imagePath:
-      'https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Prepare contributor welcome desk', 'Set up badges, project stickers and first-contribution guides.', 'Completed', 'organizer'),
-      task('Capture lightning talk recordings', 'Record talks, label files and archive approved recordings.', 'Completed', 'lucas'),
-      task('Send post-event resource pack', 'Send presentations, project links and the feedback form.', 'Completed', 'emma'),
-      task('Review attendee feedback', 'Summarize recurring feedback and recommendations for the next edition.', 'In Progress', 'noah'),
+      task('Prepare contributor welcome desk', 'Completed', 'organizer'),
+      task('Capture lightning talk recordings', 'Completed', 'lucas'),
+      task('Send post-event resource pack', 'Completed', 'emma'),
+      task('Review attendee feedback themes', 'In Progress', 'noah'),
     ],
   },
   {
     name: 'Indie Makers Demo Evening',
-    description:
-      'A fast-paced demo night where independent builders and early-stage founders present working products, receive audience questions and meet collaborators.',
-    date: relativeDate(baseDate, 45, 18),
+    description: 'A demo night where independent builders and early-stage founders present working products, receive audience questions and meet potential collaborators.',
+    date: addDays(baseDate, 45, 18),
     organizerKey: 'manager',
     participantKeys: ['participant', 'camille', 'hugo', 'lina', 'thomas', 'ines'],
     isOnline: false,
-    imagePath:
-      'https://images.unsplash.com/photo-1511578314322-379afb476865?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1511578314322-379afb476865?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Finalize demo order', 'Lock the demo order according to setup requirements.', 'In Progress', 'organizer'),
-      task('Validate adapter and laptop kit', 'Test HDMI, USB-C adapters, guest Wi-Fi and backup laptop.', 'Pending', 'lucas'),
-      task('Prepare founder check-in packs', 'Prepare badges, demo order cards and Wi-Fi instructions.', 'Pending', 'sofia'),
-      task('Test audience voting', 'Validate QR voting and prepare a manual fallback tally.', 'Pending', 'emma'),
-      task('Prepare social recap', 'Prepare the photo shot list and winner announcement assets.', 'Pending', 'noah'),
+      task('Finalize twelve-team demo order', 'In Progress', 'organizer'),
+      task('Validate demo laptop and adapter kit', 'Pending', 'lucas'),
+      task('Prepare founder check-in packs', 'Pending', 'sofia'),
+      task('Coordinate audience voting flow', 'Pending', 'emma'),
+      task('Schedule social recap assets', 'Pending', 'noah'),
     ],
   },
   {
     name: 'Data & AI for Operations Workshop',
-    description:
-      'A practical online workshop for operations and platform teams exploring AI-assisted triage, knowledge retrieval, workflow orchestration, evaluation and human review.',
-    date: relativeDate(baseDate, 21, 13),
+    description: 'A practical online workshop for operations and platform teams exploring AI-assisted incident triage, knowledge retrieval, workflow orchestration, evaluation and human review.',
+    date: addDays(baseDate, 21, 13),
     organizerKey: 'lea',
     participantKeys: ['sarah', 'mehdi', 'lina', 'thomas', 'julien'],
     isOnline: true,
     zoomLink: 'https://zoom.us/j/00000000002',
-    imagePath:
-      'https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Publish preparation guide', 'Send environment requirements, sample data and pre-reading list.', 'Completed', 'emma'),
-      task('Validate exercise datasets', 'Run every workshop exercise against final synthetic datasets.', 'In Progress', 'organizer'),
-      task('Prepare facilitator rooms', 'Assign facilitators, timings and expected outputs.', 'Pending', 'noah'),
-      task('Test fallback conference setup', 'Validate backup host access and downloadable exercise files.', 'Pending', 'lucas'),
+      task('Publish workshop preparation guide', 'Completed', 'emma'),
+      task('Validate exercise datasets', 'In Progress', 'organizer'),
+      task('Prepare facilitator breakout rooms', 'Pending', 'noah'),
+      task('Test screen-sharing fallback plan', 'Pending', 'lucas'),
     ],
   },
   {
     name: 'Bright Futures Fundraising Gala',
-    description:
-      'A fundraising gala supporting digital inclusion programs, with a welcome reception, beneficiary stories, seated dinner, live auction and closing music set.',
-    date: relativeDate(baseDate, 68, 19),
+    description: 'A fundraising gala supporting digital inclusion programs, with a welcome reception, beneficiary stories, seated dinner, live auction and closing music set.',
+    date: addDays(baseDate, 68, 19),
     organizerKey: 'lea',
     participantKeys: ['camille', 'sarah', 'mehdi', 'lina', 'thomas', 'ines'],
     isOnline: false,
-    imagePath:
-      'https://images.unsplash.com/photo-1507501336603-6e31db2be093?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1507501336603-6e31db2be093?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Finalize donor seating plan', 'Reconcile table hosts, accessibility needs and late RSVP changes.', 'In Progress', 'sofia'),
-      task('Prepare live auction runbook', 'Document auction order, bidder capture and payment handoff.', 'Pending', 'organizer'),
-      task('Coordinate beneficiary speakers', 'Confirm transport, arrival, support and stage rehearsal.', 'Pending', 'emma'),
-      task('Validate payment stations', 'Test card readers, receipts and backup connectivity.', 'Pending', 'lucas'),
-      task('Prepare volunteer briefing packs', 'Prepare role cards, floor map and escalation contacts.', 'Pending', 'noah'),
+      task('Finalize donor seating plan', 'In Progress', 'sofia'),
+      task('Prepare live auction runbook', 'Pending', 'organizer'),
+      task('Coordinate beneficiary speaker support', 'Pending', 'emma'),
+      task('Validate donation payment stations', 'Pending', 'lucas'),
+      task('Prepare volunteer briefing packs', 'Pending', 'noah'),
     ],
   },
   {
     name: 'Customer Community Breakfast',
-    description:
-      'A small-format breakfast for customer success, product and community leaders using facilitated roundtables and a practical working session.',
-    date: relativeDate(baseDate, 3, 8),
+    description: 'A small-format breakfast for customer success, product and community leaders using facilitated roundtables and a practical working session.',
+    date: addDays(baseDate, 3, 8),
     organizerKey: 'karim',
     participantKeys: ['participant', 'camille', 'sarah', 'thomas'],
     isOnline: false,
-    imagePath:
-      'https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Confirm roundtable hosts', 'Match each topic with an experienced host and send the discussion guide.', 'Completed', 'organizer'),
-      task('Review breakfast order', 'Confirm coffee, pastries, fruit and dietary alternatives.', 'In Progress', 'sofia'),
-      task('Print working templates', 'Print experiment canvases and table signage.', 'Pending', 'emma'),
-      task('Prepare venue opening checklist', 'Document room setup, check-in and signage checks.', 'Pending', 'lucas'),
+      task('Confirm roundtable host assignments', 'Completed', 'organizer'),
+      task('Review final breakfast order', 'In Progress', 'sofia'),
+      task('Print working-session templates', 'Pending', 'emma'),
+      task('Prepare venue opening checklist', 'Pending', 'lucas'),
     ],
   },
   {
     name: 'Security Incident Tabletop Exercise',
-    description:
-      'A private online tabletop exercise simulating a credential leak, suspicious access and partial service degradation, followed by a structured retrospective.',
-    date: relativeDate(baseDate, 12, 14),
+    description: 'A private online tabletop exercise simulating a credential leak, suspicious access and partial service degradation, followed by a structured retrospective.',
+    date: addDays(baseDate, 12, 14),
     organizerKey: 'karim',
     participantKeys: ['hugo', 'mehdi', 'thomas', 'julien'],
     isOnline: true,
     zoomLink: 'https://zoom.us/j/00000000003',
-    imagePath:
-      'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?auto=format&fit=crop&w=1400&q=80',
+    imagePath: 'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?auto=format&fit=crop&w=1400&q=80',
     tasks: [
-      task('Validate incident timeline', 'Review scenario injects, decision points and dependencies.', 'Completed', 'organizer'),
-      task('Prepare observer template', 'Create a structured sheet covering detection, ownership and recovery.', 'In Progress', 'noah'),
-      task('Test private room access', 'Verify meeting access controls and backup host permissions.', 'Pending', 'lucas'),
-      task('Prepare retrospective action log', 'Create the action tracker with owner, severity and due date fields.', 'Pending', 'emma'),
+      task('Validate incident scenario timeline', 'Completed', 'organizer'),
+      task('Prepare observer note template', 'In Progress', 'noah'),
+      task('Test private exercise room access', 'Pending', 'lucas'),
+      task('Prepare retrospective action log', 'Pending', 'emma'),
     ],
   },
 ];
+
+const demoEventNames = (events) => [
+  'Festivio Community Meetup',
+  ...events.map((event) => event.name),
+];
+
+const removeExistingDemoData = async (events) => {
+  for (const name of demoEventNames(events)) {
+    const matches = await Event.find({ name }).select('_id');
+    for (const match of matches) {
+      await Task.deleteMany({ event: match._id });
+    }
+    await Event.deleteMany({ name });
+  }
+
+  for (const demoUser of demoUsers) {
+    await User.updateOne(
+      { email: demoUser.email },
+      { $set: { events: [], tasks: [] } }
+    );
+  }
+};
 
 const seed = async () => {
   if (config.isProduction) {
@@ -230,7 +232,7 @@ const seed = async () => {
     const password = await bcrypt.hash(demoPassword, 12);
     const users = {};
 
-    for (const definition of DEMO_USER_DEFINITIONS) {
+    for (const definition of demoUsers) {
       const { key, ...profile } = definition;
       users[key] = await User.findOneAndUpdate(
         { email: profile.email },
@@ -239,31 +241,12 @@ const seed = async () => {
       );
     }
 
-    const eventDefinitions = buildDemoEvents(new Date());
-    const demoEventNames = [
-      ...LEGACY_DEMO_EVENT_NAMES,
-      ...eventDefinitions.map((event) => event.name),
-    ];
-
-    const existingDemoEvents = await Event.find({
-      name: { $in: demoEventNames },
-    }).select('_id');
-    const existingDemoEventIds = existingDemoEvents.map((event) => event._id);
-
-    if (existingDemoEventIds.length > 0) {
-      await Task.deleteMany({ event: { $in: existingDemoEventIds } });
-    }
-    await Event.deleteMany({ name: { $in: demoEventNames } });
-
-    const demoEmails = DEMO_USER_DEFINITIONS.map((demoUser) => demoUser.email);
-    await User.updateMany(
-      { email: { $in: demoEmails } },
-      { $set: { events: [], tasks: [] } }
-    );
+    const events = buildEvents(new Date());
+    await removeExistingDemoData(events);
 
     let taskCount = 0;
 
-    for (const definition of eventDefinitions) {
+    for (const definition of events) {
       const organizer = users[definition.organizerKey];
       if (!organizer) throw new Error(`Unknown organizer key ${definition.organizerKey}`);
 
@@ -315,16 +298,16 @@ const seed = async () => {
         { $addToSet: { events: event._id } }
       );
 
-      await User.updateMany(
-        { _id: { $in: participants.map((participant) => participant._id) } },
-        { $addToSet: { events: event._id } }
-      );
+      for (const participant of participants) {
+        await User.updateOne(
+          { _id: participant._id },
+          { $addToSet: { events: event._id } }
+        );
+      }
     }
 
     console.info('Festivio realistic demo dataset seeded.');
-    console.info(
-      `Created ${DEMO_USER_DEFINITIONS.length} users, ${eventDefinitions.length} events and ${taskCount} tasks.`
-    );
+    console.info(`Created ${demoUsers.length} users, ${events.length} events and ${taskCount} tasks.`);
     console.info(`Shared demo password: ${demoPassword}`);
     console.info('Primary accounts:');
     console.info('  admin@festivio.local       (ROLE_ADMIN)');

--- a/backend/scripts/seed.js
+++ b/backend/scripts/seed.js
@@ -4,7 +4,11 @@ const { config } = require('../config/env');
 const User = require('../models/User');
 const Event = require('../models/Event');
 const Task = require('../models/Task');
-const { ROLES } = require('../constants/roles');
+const {
+  DEMO_USER_DEFINITIONS,
+  LEGACY_DEMO_EVENT_NAMES,
+  buildDemoEvents,
+} = require('./demoData');
 
 const seed = async () => {
   if (config.isProduction) {
@@ -17,71 +21,136 @@ const seed = async () => {
   }
 
   await connectDB();
-  const password = await bcrypt.hash(demoPassword, 12);
-  const definitions = [
-    ['Ada', 'Admin', 'admin', 'admin@festivio.local', ROLES.ADMIN],
-    [
-      'Morgan',
-      'Manager',
-      'manager',
-      'manager@festivio.local',
-      ROLES.ORGANIZER_ADMIN,
-    ],
-    [
-      'Owen',
-      'Organizer',
-      'organizer',
-      'organizer@festivio.local',
-      ROLES.ORGANIZER,
-    ],
-    [
-      'Pia',
-      'Participant',
-      'participant',
-      'participant@festivio.local',
-      ROLES.PARTICIPANT,
-    ],
-  ];
 
-  const users = {};
-  for (const [firstName, lastName, username, email, role] of definitions) {
-    users[role] = await User.findOneAndUpdate(
-      { email },
-      { firstName, lastName, username, email, role, password, isVerified: true },
-      { upsert: true, new: true, setDefaultsOnInsert: true }
+  try {
+    const password = await bcrypt.hash(demoPassword, 12);
+    const users = {};
+
+    for (const definition of DEMO_USER_DEFINITIONS) {
+      const { key, ...profile } = definition;
+      users[key] = await User.findOneAndUpdate(
+        { email: profile.email },
+        {
+          $set: {
+            ...profile,
+            password,
+            isVerified: true,
+          },
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      );
+    }
+
+    const eventDefinitions = buildDemoEvents(new Date());
+    const demoEventNames = [
+      ...LEGACY_DEMO_EVENT_NAMES,
+      ...eventDefinitions.map((event) => event.name),
+    ];
+
+    const existingDemoEvents = await Event.find({
+      name: { $in: demoEventNames },
+    }).select('_id');
+
+    const existingDemoEventIds = existingDemoEvents.map((event) => event._id);
+    if (existingDemoEventIds.length > 0) {
+      await Task.deleteMany({ event: { $in: existingDemoEventIds } });
+    }
+    await Event.deleteMany({ name: { $in: demoEventNames } });
+
+    const demoEmails = DEMO_USER_DEFINITIONS.map((user) => user.email);
+    await User.updateMany(
+      { email: { $in: demoEmails } },
+      { $set: { events: [], tasks: [] } }
     );
+
+    let taskCount = 0;
+
+    for (const definition of eventDefinitions) {
+      const organizer = users[definition.organizerKey];
+      if (!organizer) {
+        throw new Error(
+          `Unknown organizer key "${definition.organizerKey}" for ${definition.name}`
+        );
+      }
+
+      const participants = definition.participantKeys.map((key) => {
+        const participant = users[key];
+        if (!participant) {
+          throw new Error(`Unknown participant key "${key}" for ${definition.name}`);
+        }
+        return participant;
+      });
+
+      const event = await Event.create({
+        name: definition.name,
+        description: definition.description,
+        date: definition.date,
+        organizer: organizer._id,
+        participants: participants.map((participant) => participant._id),
+        isOnline: definition.isOnline,
+        zoomLink: definition.isOnline ? definition.zoomLink : undefined,
+        imagePath: definition.imagePath,
+      });
+
+      const taskIds = [];
+      for (const taskDefinition of definition.tasks) {
+        const assignee = users[taskDefinition.assignedToKey];
+        if (!assignee) {
+          throw new Error(
+            `Unknown assignee key "${taskDefinition.assignedToKey}" for ${taskDefinition.title}`
+          );
+        }
+
+        const task = await Task.create({
+          title: taskDefinition.title,
+          description: taskDefinition.description,
+          status: taskDefinition.status,
+          assignedTo: assignee._id,
+          event: event._id,
+          createdBy: organizer._id,
+        });
+
+        taskIds.push(task._id);
+        taskCount += 1;
+
+        await User.updateOne(
+          { _id: assignee._id },
+          { $addToSet: { tasks: task._id } }
+        );
+      }
+
+      event.tasks = taskIds;
+      await event.save();
+
+      await User.updateOne(
+        { _id: organizer._id },
+        { $addToSet: { events: event._id } }
+      );
+
+      if (participants.length > 0) {
+        await User.updateMany(
+          { _id: { $in: participants.map((participant) => participant._id) } },
+          { $addToSet: { events: event._id } }
+        );
+      }
+    }
+
+    console.info('Festivio realistic demo dataset seeded.');
+    console.info(
+      `Created ${DEMO_USER_DEFINITIONS.length} users, ${eventDefinitions.length} events and ${taskCount} tasks.`
+    );
+    console.info(`Shared demo password: ${demoPassword}`);
+    console.info('Primary accounts:');
+    console.info('  admin@festivio.local       (ROLE_ADMIN)');
+    console.info('  manager@festivio.local     (ROLE_ORGANIZER_ADMIN)');
+    console.info('  organizer@festivio.local   (ROLE_ORGANIZER)');
+    console.info('  participant@festivio.local (ROLE_PARTICIPANT)');
+  } finally {
+    await disconnectDB();
   }
-
-  await Event.deleteMany({ name: 'Festivio Community Meetup' });
-  const event = await Event.create({
-    name: 'Festivio Community Meetup',
-    description:
-      'Synthetic local demo event for validating roles, participants and tasks.',
-    date: new Date('2027-01-15T18:00:00.000Z'),
-    organizer: users[ROLES.ORGANIZER_ADMIN]._id,
-    participants: [users[ROLES.PARTICIPANT]._id],
-    isOnline: false,
-  });
-
-  const task = await Task.create({
-    title: 'Prepare attendee check-in',
-    description:
-      'Validate the check-in desk and attendee list before doors open.',
-    status: 'In Progress',
-    assignedTo: users[ROLES.ORGANIZER]._id,
-    event: event._id,
-    createdBy: users[ROLES.ORGANIZER_ADMIN]._id,
-  });
-  event.tasks = [task._id];
-  await event.save();
-
-  console.info('Festivio demo data seeded.');
-  console.info('Accounts: admin, manager, organizer, participant @festivio.local');
-  await disconnectDB();
 };
 
-seed().catch(async (error) => {
+seed().catch((error) => {
   console.error(`Seed failed: ${error.message}`);
-  await disconnectDB();
   process.exit(1);
 });

--- a/backend/services/emailTemplates.js
+++ b/backend/services/emailTemplates.js
@@ -1,0 +1,183 @@
+const escapeHtml = (value = '') =>
+  String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+
+const appName = 'Festivio';
+const appTagline = 'Plan. Coordinate. Deliver.';
+
+const brandMark = `
+  <div style="display:inline-flex;align-items:center;gap:12px">
+    <div style="width:44px;height:44px;border-radius:16px;background:linear-gradient(135deg,#6f6cf6 0%,#3b82f6 100%);box-shadow:0 18px 45px rgba(80,91,230,.32);display:inline-flex;align-items:center;justify-content:center;color:#ffffff;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;font-weight:900;font-size:18px;letter-spacing:-.04em">F</div>
+    <div style="text-align:left">
+      <div style="font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;font-weight:850;font-size:22px;line-height:1;color:#111317;letter-spacing:-.04em">Festivio</div>
+      <div style="font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;font-weight:650;font-size:11px;line-height:1.4;color:#7b8190;letter-spacing:.08em;text-transform:uppercase;margin-top:5px">${appTagline}</div>
+    </div>
+  </div>`;
+
+const baseText = ({ greeting, intro, ctaLabel, ctaUrl, note, securityNote }) => [
+  greeting,
+  '',
+  intro,
+  '',
+  `${ctaLabel}: ${ctaUrl}`,
+  '',
+  note,
+  '',
+  securityNote,
+  '',
+  `${appName} — ${appTagline}`,
+].join('\n');
+
+const renderEmail = ({
+  preheader,
+  eyebrow,
+  title,
+  greeting,
+  intro,
+  ctaLabel,
+  ctaUrl,
+  note,
+  securityNote,
+}) => {
+  const safe = {
+    preheader: escapeHtml(preheader),
+    eyebrow: escapeHtml(eyebrow),
+    title: escapeHtml(title),
+    greeting: escapeHtml(greeting),
+    intro: escapeHtml(intro),
+    ctaLabel: escapeHtml(ctaLabel),
+    ctaUrl: escapeHtml(ctaUrl),
+    note: escapeHtml(note),
+    securityNote: escapeHtml(securityNote),
+  };
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="color-scheme" content="light">
+  <meta name="supported-color-schemes" content="light">
+  <title>${safe.title}</title>
+</head>
+<body style="margin:0;padding:0;background:#f5f5f2;color:#111317;font-family:Inter,-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;-webkit-font-smoothing:antialiased">
+  <div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent">${safe.preheader}</div>
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:radial-gradient(circle at top left,rgba(111,108,246,.18),transparent 32%),radial-gradient(circle at top right,rgba(59,130,246,.16),transparent 30%),#f5f5f2;padding:32px 16px">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;margin:0 auto">
+          <tr>
+            <td style="padding:10px 0 24px;text-align:center">${brandMark}</td>
+          </tr>
+          <tr>
+            <td style="border:1px solid rgba(255,255,255,.78);border-radius:30px;background:linear-gradient(145deg,rgba(255,255,255,.86),rgba(255,255,255,.58));box-shadow:0 32px 90px rgba(17,24,39,.10);overflow:hidden">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td style="padding:40px 40px 22px">
+                    <div style="display:inline-block;padding:7px 11px;border-radius:999px;background:rgba(111,108,246,.10);border:1px solid rgba(111,108,246,.18);color:#5652e8;font-weight:800;font-size:11px;letter-spacing:.08em;text-transform:uppercase">${safe.eyebrow}</div>
+                    <h1 style="margin:18px 0 0;font-size:34px;line-height:1.08;letter-spacing:-.05em;color:#111317;font-weight:850">${safe.title}</h1>
+                    <p style="margin:22px 0 0;font-size:16px;line-height:1.7;color:#4b5563">${safe.greeting}</p>
+                    <p style="margin:12px 0 0;font-size:16px;line-height:1.7;color:#4b5563">${safe.intro}</p>
+                    <table role="presentation" cellspacing="0" cellpadding="0" style="margin:30px 0 0">
+                      <tr>
+                        <td style="border-radius:14px;background:#111317;box-shadow:0 16px 34px rgba(17,19,23,.20)">
+                          <a href="${safe.ctaUrl}" style="display:inline-block;padding:15px 22px;border-radius:14px;color:#ffffff;text-decoration:none;font-size:14px;font-weight:800;letter-spacing:-.01em">${safe.ctaLabel}</a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 40px 38px">
+                    <div style="padding:18px 20px;border-radius:18px;background:rgba(248,248,246,.78);border:1px solid rgba(17,19,23,.08)">
+                      <p style="margin:0;font-size:14px;line-height:1.65;color:#5f6675">${safe.note}</p>
+                    </div>
+                    <p style="margin:20px 0 0;font-size:13px;line-height:1.7;color:#8a91a0">${safe.securityNote}</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 8px 0;text-align:center;color:#8a91a0;font-size:12px;line-height:1.7">
+              <div style="font-weight:750;color:#6b7280">Festivio</div>
+              <div>Event operations, participant coordination and task execution from one workspace.</div>
+              <div style="margin-top:8px">This is an automated transactional email. Please do not reply directly.</div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+};
+
+const buildVerificationEmail = ({ firstName, verificationLink }) => {
+  const greeting = `Hi ${firstName || 'there'},`;
+  const intro = 'Welcome to Festivio. Confirm your email address to activate your account and access your event workspace securely.';
+  const ctaLabel = 'Verify email address';
+  const note = 'This verification link is valid for 24 hours. After verification, you can sign in and continue setting up your event operations workspace.';
+  const securityNote = 'If you did not create a Festivio account, you can safely ignore this email.';
+
+  return {
+    html: renderEmail({
+      preheader: 'Confirm your Festivio email address to activate your account.',
+      eyebrow: 'Account verification',
+      title: 'Confirm your email address',
+      greeting,
+      intro,
+      ctaLabel,
+      ctaUrl: verificationLink,
+      note,
+      securityNote,
+    }),
+    text: baseText({
+      greeting,
+      intro,
+      ctaLabel,
+      ctaUrl: verificationLink,
+      note,
+      securityNote,
+    }),
+  };
+};
+
+const buildPasswordResetEmail = ({ firstName, resetLink }) => {
+  const greeting = `Hi ${firstName || 'there'},`;
+  const intro = 'We received a request to reset the password for your Festivio account. Use the secure link below to choose a new password.';
+  const ctaLabel = 'Reset password';
+  const note = 'This reset link expires in one hour. For your security, the link can only be used for this password reset flow.';
+  const securityNote = 'If you did not request a password reset, you can ignore this email. Your current password will stay unchanged.';
+
+  return {
+    html: renderEmail({
+      preheader: 'Reset your Festivio password securely.',
+      eyebrow: 'Password recovery',
+      title: 'Reset your password',
+      greeting,
+      intro,
+      ctaLabel,
+      ctaUrl: resetLink,
+      note,
+      securityNote,
+    }),
+    text: baseText({
+      greeting,
+      intro,
+      ctaLabel,
+      ctaUrl: resetLink,
+      note,
+      securityNote,
+    }),
+  };
+};
+
+module.exports = {
+  buildPasswordResetEmail,
+  buildVerificationEmail,
+};


### PR DESCRIPTION
## Summary
- Replace the demo seed with a richer realistic dataset for users, events, tasks and event participation.
- Make the demo seed idempotent and safe for local/demo usage.
- Add professional branded Festivio transactional email templates.
- Wire account verification and password reset emails to the new templates.

## Testing
- Manual local Docker flow expected:
  - `docker compose up -d --build`
  - `docker compose exec backend npm run seed:demo`
- Email templates can be inspected through Mailpit at `http://localhost:8025` after account registration or password reset.