### PR TITLE
feat(api): add pagination, search and route rate limits

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -20,7 +20,7 @@ const taskRoutes = require('./routes/taskRoutes');
 const app = express();
 
 app.disable('x-powered-by');
-app.set('trust proxy', config.isProduction ? 1 : false);
+app.set('trust proxy', config.trustProxy);
 
 app.use((req, res, next) => {
   const requestId = req.get('x-request-id') || crypto.randomUUID();

--- a/backend/config/env.js
+++ b/backend/config/env.js
@@ -17,7 +17,19 @@ const parseBoolean = (value, fallback) => {
   return value.toLowerCase() === 'true';
 };
 
+const parseTrustProxy = (value, fallback) => {
+  if (value === undefined) return fallback;
+
+  const normalized = value.trim().toLowerCase();
+  if (['false', '0', 'off', 'none'].includes(normalized)) return false;
+  if (['true', '1', 'on'].includes(normalized)) return 1;
+
+  const parsed = Number.parseInt(normalized, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
 const nodeEnv = process.env.NODE_ENV || process.env.ENV || 'development';
+const isProduction = nodeEnv === 'production';
 const port = parseInteger(process.env.PORT, 5000);
 const frontendUrl = stripTrailingSlash(
   process.env.FRONTEND_URL || 'http://localhost:3000'
@@ -32,7 +44,7 @@ const corsOrigins = (process.env.CORS_ORIGINS || frontendUrl)
 
 const config = Object.freeze({
   nodeEnv,
-  isProduction: nodeEnv === 'production',
+  isProduction,
   port,
   mongoUri: process.env.MONGO_URI,
   mongoServerSelectionTimeoutMs: parseInteger(
@@ -52,6 +64,7 @@ const config = Object.freeze({
   accessTokenTtl: process.env.ACCESS_TOKEN_TTL || '15m',
   refreshTokenTtl: process.env.REFRESH_TOKEN_TTL || '30d',
   refreshCookieName: process.env.REFRESH_COOKIE_NAME || 'festivio_refresh',
+  trustProxy: parseTrustProxy(process.env.TRUST_PROXY, isProduction ? 1 : false),
   frontendUrl,
   backendUrl,
   corsOrigins,

--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -3,6 +3,11 @@ const Event = require('../models/Event');
 const EventDTO = require('../dtos/EventDTO');
 const { config } = require('../config/env');
 const { ROLES } = require('../constants/roles');
+const {
+  buildPaginationMeta,
+  getPaginationParams,
+  getSearchRegex,
+} = require('../utils/pagination');
 
 const uploadImage = async (file) => {
   if (!file) return null;
@@ -26,6 +31,43 @@ const canManageEvent = (event, user) =>
   user.role === ROLES.ADMIN ||
   (user.role === ROLES.ORGANIZER_ADMIN &&
     event.organizer.toString() === user.userId);
+
+const getEventSort = (sort = 'date_asc') => {
+  const options = {
+    date_asc: { date: 1, createdAt: -1 },
+    date_desc: { date: -1, createdAt: -1 },
+    newest: { createdAt: -1 },
+    oldest: { createdAt: 1 },
+  };
+  return options[sort] || options.date_asc;
+};
+
+const buildEventFilter = (req) => {
+  const filter =
+    req.user.role === ROLES.ORGANIZER_ADMIN
+      ? { organizer: req.user.userId }
+      : {};
+
+  const searchRegex = getSearchRegex(req.query.search);
+  if (searchRegex) {
+    filter.$or = [{ name: searchRegex }, { description: searchRegex }];
+  }
+
+  if (req.query.type === 'online') {
+    filter.isOnline = true;
+  } else if (req.query.type === 'in_person') {
+    filter.isOnline = false;
+  }
+
+  const now = new Date();
+  if (req.query.timeframe === 'upcoming') {
+    filter.date = { $gte: now };
+  } else if (req.query.timeframe === 'past') {
+    filter.date = { $lt: now };
+  }
+
+  return filter;
+};
 
 exports.createEvent = async (req, res) => {
   try {
@@ -62,15 +104,33 @@ exports.createEvent = async (req, res) => {
 
 exports.getEvents = async (req, res) => {
   try {
-    const filter =
-      req.user.role === ROLES.ORGANIZER_ADMIN
-        ? { organizer: req.user.userId }
-        : {};
-    const events = await Event.find(filter)
-      .populate('participants', 'firstName lastName email role')
-      .populate('tasks')
-      .sort({ date: 1 });
-    return res.json({ events: events.map((event) => new EventDTO(event)) });
+    const { page, limit, skip } = getPaginationParams(req.query, {
+      defaultLimit: 9,
+      maxLimit: 30,
+    });
+    const filter = buildEventFilter(req);
+    const sort = getEventSort(req.query.sort);
+
+    const [events, total] = await Promise.all([
+      Event.find(filter)
+        .populate('participants', 'firstName lastName email role')
+        .populate('tasks')
+        .sort(sort)
+        .skip(skip)
+        .limit(limit),
+      Event.countDocuments(filter),
+    ]);
+
+    return res.json({
+      events: events.map((event) => new EventDTO(event)),
+      pagination: buildPaginationMeta({ page, limit, total }),
+      filters: {
+        search: req.query.search || '',
+        sort: req.query.sort || 'date_asc',
+        timeframe: req.query.timeframe || 'all',
+        type: req.query.type || 'all',
+      },
+    });
   } catch (error) {
     console.error('Event listing failed:', error.message);
     return res.status(500).json({ message: 'Unable to fetch events' });

--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -1,4 +1,3 @@
-const mongoose = require('mongoose');
 const axios = require('axios');
 const Event = require('../models/Event');
 const EventDTO = require('../dtos/EventDTO');
@@ -7,7 +6,6 @@ const { ROLES } = require('../constants/roles');
 const {
   buildPaginationMeta,
   getPaginationParams,
-  getSearchRegex,
 } = require('../utils/pagination');
 
 const uploadImage = async (file) => {
@@ -33,26 +31,27 @@ const canManageEvent = (event, user) =>
   (user.role === ROLES.ORGANIZER_ADMIN &&
     event.organizer.toString() === user.userId);
 
-const getEventSort = (sort = 'date_asc') => {
-  const options = {
-    date_asc: { date: 1, createdAt: -1 },
-    date_desc: { date: -1, createdAt: -1 },
-    newest: { createdAt: -1 },
-    oldest: { createdAt: 1 },
+const dateValue = (value) => new Date(value || 0).getTime();
+
+const getEventComparator = (sort = 'date_asc') => {
+  const comparators = {
+    date_asc: (left, right) =>
+      dateValue(left.date) - dateValue(right.date) ||
+      dateValue(right.createdAt) - dateValue(left.createdAt),
+    date_desc: (left, right) =>
+      dateValue(right.date) - dateValue(left.date) ||
+      dateValue(right.createdAt) - dateValue(left.createdAt),
+    newest: (left, right) => dateValue(right.createdAt) - dateValue(left.createdAt),
+    oldest: (left, right) => dateValue(left.createdAt) - dateValue(right.createdAt),
   };
-  return options[sort] || options.date_asc;
+  return comparators[sort] || comparators.date_asc;
 };
 
-const buildEventFilter = (req) => {
+const buildBaseEventFilter = (req) => {
   const filter =
     req.user.role === ROLES.ORGANIZER_ADMIN
       ? { organizer: req.user.userId }
       : {};
-
-  const searchRegex = getSearchRegex(req.query.search);
-  if (searchRegex) {
-    filter.$or = [{ name: searchRegex }, { description: searchRegex }];
-  }
 
   if (req.query.type === 'online') {
     filter.isOnline = true;
@@ -60,14 +59,24 @@ const buildEventFilter = (req) => {
     filter.isOnline = false;
   }
 
-  const now = new Date();
-  if (req.query.timeframe === 'upcoming') {
-    filter.date = { $gte: now };
-  } else if (req.query.timeframe === 'past') {
-    filter.date = { $lt: now };
-  }
-
   return filter;
+};
+
+const eventMatchesSearch = (event, search) => {
+  const normalizedSearch = String(search || '').trim().toLowerCase();
+  if (!normalizedSearch) return true;
+
+  const haystack = `${event.name || ''} ${event.description || ''}`.toLowerCase();
+  return haystack.includes(normalizedSearch);
+};
+
+const eventMatchesTimeframe = (event, timeframe) => {
+  const eventDate = dateValue(event.date);
+  const now = Date.now();
+
+  if (timeframe === 'upcoming') return eventDate >= now;
+  if (timeframe === 'past') return eventDate < now;
+  return true;
 };
 
 exports.createEvent = async (req, res) => {
@@ -109,26 +118,28 @@ exports.getEvents = async (req, res) => {
       defaultLimit: 9,
       maxLimit: 30,
     });
-    const filter = mongoose.trusted(buildEventFilter(req));
-    const sort = getEventSort(req.query.sort);
+    const baseFilter = buildBaseEventFilter(req);
+    const sort = req.query.sort || 'date_asc';
+    const timeframe = req.query.timeframe || 'all';
 
-    const [events, total] = await Promise.all([
-      Event.find(filter)
-        .populate('participants', 'firstName lastName email role')
-        .populate('tasks')
-        .sort(sort)
-        .skip(skip)
-        .limit(limit),
-      Event.countDocuments(filter),
-    ]);
+    const allEvents = await Event.find(baseFilter)
+      .populate('participants', 'firstName lastName email role')
+      .populate('tasks');
+
+    const filteredEvents = allEvents
+      .filter((event) => eventMatchesSearch(event, req.query.search))
+      .filter((event) => eventMatchesTimeframe(event, timeframe))
+      .sort(getEventComparator(sort));
+
+    const paginatedEvents = filteredEvents.slice(skip, skip + limit);
 
     return res.json({
-      events: events.map((event) => new EventDTO(event)),
-      pagination: buildPaginationMeta({ page, limit, total }),
+      events: paginatedEvents.map((event) => new EventDTO(event)),
+      pagination: buildPaginationMeta({ page, limit, total: filteredEvents.length }),
       filters: {
         search: req.query.search || '',
-        sort: req.query.sort || 'date_asc',
-        timeframe: req.query.timeframe || 'all',
+        sort,
+        timeframe,
         type: req.query.type || 'all',
       },
     });

--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -69,6 +69,11 @@ const buildEventFilter = (req) => {
   return filter;
 };
 
+const trustedServerFilterOptions = {
+  sanitizeFilter: false,
+  strictQuery: true,
+};
+
 exports.createEvent = async (req, res) => {
   try {
     const { name, description, date, participants, isOnline, zoomLink } = req.body;
@@ -113,12 +118,13 @@ exports.getEvents = async (req, res) => {
 
     const [events, total] = await Promise.all([
       Event.find(filter)
+        .setOptions(trustedServerFilterOptions)
         .populate('participants', 'firstName lastName email role')
         .populate('tasks')
         .sort(sort)
         .skip(skip)
         .limit(limit),
-      Event.countDocuments(filter),
+      Event.countDocuments(filter).setOptions(trustedServerFilterOptions),
     ]);
 
     return res.json({

--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -1,3 +1,4 @@
+const mongoose = require('mongoose');
 const axios = require('axios');
 const Event = require('../models/Event');
 const EventDTO = require('../dtos/EventDTO');
@@ -69,11 +70,6 @@ const buildEventFilter = (req) => {
   return filter;
 };
 
-const trustedServerFilterOptions = {
-  sanitizeFilter: false,
-  strictQuery: true,
-};
-
 exports.createEvent = async (req, res) => {
   try {
     const { name, description, date, participants, isOnline, zoomLink } = req.body;
@@ -113,18 +109,17 @@ exports.getEvents = async (req, res) => {
       defaultLimit: 9,
       maxLimit: 30,
     });
-    const filter = buildEventFilter(req);
+    const filter = mongoose.trusted(buildEventFilter(req));
     const sort = getEventSort(req.query.sort);
 
     const [events, total] = await Promise.all([
       Event.find(filter)
-        .setOptions(trustedServerFilterOptions)
         .populate('participants', 'firstName lastName email role')
         .populate('tasks')
         .sort(sort)
         .skip(skip)
         .limit(limit),
-      Event.countDocuments(filter).setOptions(trustedServerFilterOptions),
+      Event.countDocuments(filter),
     ]);
 
     return res.json({

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -12,10 +12,6 @@ const {
 
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
 const TASK_STATUSES = new Set(['Pending', 'In Progress', 'Completed']);
-const trustedServerFilterOptions = {
-  sanitizeFilter: false,
-  strictQuery: true,
-};
 
 const toObjectId = (value) => {
   if (typeof value !== 'string' || !OBJECT_ID_PATTERN.test(value)) return null;
@@ -160,18 +156,17 @@ exports.getAllTasks = async (req, res) => {
       defaultLimit: 10,
       maxLimit: 50,
     });
-    const filter = await buildTaskFilter(req);
+    const filter = mongoose.trusted(await buildTaskFilter(req));
     const sort = getTaskSort(req.query.sort);
 
     const [tasks, total] = await Promise.all([
       Task.find(filter)
-        .setOptions(trustedServerFilterOptions)
         .populate('assignedTo', 'firstName lastName email role')
         .populate('event', 'name date isOnline')
         .sort(sort)
         .skip(skip)
         .limit(limit),
-      Task.countDocuments(filter).setOptions(trustedServerFilterOptions),
+      Task.countDocuments(filter),
     ]);
 
     return res.json({

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -7,7 +7,6 @@ const { ROLES } = require('../constants/roles');
 const {
   buildPaginationMeta,
   getPaginationParams,
-  getSearchRegex,
 } = require('../utils/pagination');
 
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
@@ -36,18 +35,38 @@ const loadManagedEvent = async (eventId, user) => {
   return { event };
 };
 
-const getTaskSort = (sort = 'newest') => {
-  const options = {
-    newest: { createdAt: -1 },
-    oldest: { createdAt: 1 },
-    status: { status: 1, createdAt: -1 },
+const dateValue = (value) => new Date(value || 0).getTime();
+
+const getTaskComparator = (sort = 'newest') => {
+  const comparators = {
+    newest: (left, right) => dateValue(right.createdAt) - dateValue(left.createdAt),
+    oldest: (left, right) => dateValue(left.createdAt) - dateValue(right.createdAt),
+    status: (left, right) =>
+      String(left.status || '').localeCompare(String(right.status || '')) ||
+      dateValue(right.createdAt) - dateValue(left.createdAt),
   };
-  return options[sort] || options.newest;
+  return comparators[sort] || comparators.newest;
 };
 
-const buildRoleScopedTaskConditions = async (user) => {
+const loadVisibleTasks = async (user) => {
+  const query = Task.find()
+    .populate('assignedTo', 'firstName lastName email role')
+    .populate('event', 'name date isOnline organizer');
+
+  if (user.role === ROLES.ADMIN) return query;
+
   if (user.role === ROLES.ORGANIZER) {
-    return [{ assignedTo: toObjectId(user.userId) }];
+    const organizerId = toObjectId(user.userId);
+    if (!organizerId) {
+      const error = new Error('Invalid authenticated user');
+      error.status = 401;
+      throw error;
+    }
+
+    const tasks = await query;
+    return tasks.filter(
+      (task) => task.assignedTo?._id?.toString() === organizerId.toString()
+    );
   }
 
   if (user.role === ROLES.ORGANIZER_ADMIN) {
@@ -58,43 +77,36 @@ const buildRoleScopedTaskConditions = async (user) => {
       throw error;
     }
 
-    const managedEvents = await Event.find({ organizer: organizerId }).select('_id');
-    if (managedEvents.length === 0) return [{ _id: null }];
-
-    return [
-      {
-        $or: managedEvents.map((event) => ({ event: event._id })),
-      },
-    ];
+    const tasks = await query;
+    return tasks.filter(
+      (task) => task.event?.organizer?.toString() === organizerId.toString()
+    );
   }
-
-  if (user.role === ROLES.ADMIN) return [];
 
   const error = new Error('Tasks are not available for this role');
   error.status = 403;
   throw error;
 };
 
-const buildTaskFilter = async (req) => {
-  const conditions = await buildRoleScopedTaskConditions(req.user);
-
-  if (req.query.status && req.query.status !== 'All') {
-    if (!TASK_STATUSES.has(req.query.status)) {
-      const error = new Error('Invalid task status');
-      error.status = 400;
-      throw error;
-    }
-    conditions.push({ status: req.query.status });
+const taskMatchesStatus = (task, status) => {
+  if (!status || status === 'All') return true;
+  if (!TASK_STATUSES.has(status)) {
+    const error = new Error('Invalid task status');
+    error.status = 400;
+    throw error;
   }
+  return task.status === status;
+};
 
-  const searchRegex = getSearchRegex(req.query.search);
-  if (searchRegex) {
-    conditions.push({
-      $or: [{ title: searchRegex }, { description: searchRegex }],
-    });
-  }
+const taskMatchesSearch = (task, search) => {
+  const normalizedSearch = String(search || '').trim().toLowerCase();
+  if (!normalizedSearch) return true;
 
-  return conditions.length > 0 ? { $and: conditions } : {};
+  const eventName = typeof task.event === 'object' ? task.event?.name : '';
+  const assignee = task.assignedTo || {};
+  const assigneeName = `${assignee.firstName || ''} ${assignee.lastName || ''}`;
+  const haystack = `${task.title || ''} ${task.description || ''} ${eventName || ''} ${assigneeName} ${assignee.email || ''}`.toLowerCase();
+  return haystack.includes(normalizedSearch);
 };
 
 exports.createTask = async (req, res) => {
@@ -156,26 +168,24 @@ exports.getAllTasks = async (req, res) => {
       defaultLimit: 10,
       maxLimit: 50,
     });
-    const filter = mongoose.trusted(await buildTaskFilter(req));
-    const sort = getTaskSort(req.query.sort);
+    const sort = req.query.sort || 'newest';
+    const status = req.query.status || 'All';
 
-    const [tasks, total] = await Promise.all([
-      Task.find(filter)
-        .populate('assignedTo', 'firstName lastName email role')
-        .populate('event', 'name date isOnline')
-        .sort(sort)
-        .skip(skip)
-        .limit(limit),
-      Task.countDocuments(filter),
-    ]);
+    const visibleTasks = await loadVisibleTasks(req.user);
+    const filteredTasks = visibleTasks
+      .filter((task) => taskMatchesStatus(task, status))
+      .filter((task) => taskMatchesSearch(task, req.query.search))
+      .sort(getTaskComparator(sort));
+
+    const paginatedTasks = filteredTasks.slice(skip, skip + limit);
 
     return res.json({
-      tasks: tasks.map((task) => new TaskDTO(task)),
-      pagination: buildPaginationMeta({ page, limit, total }),
+      tasks: paginatedTasks.map((task) => new TaskDTO(task)),
+      pagination: buildPaginationMeta({ page, limit, total: filteredTasks.length }),
       filters: {
         search: req.query.search || '',
-        sort: req.query.sort || 'newest',
-        status: req.query.status || 'All',
+        sort,
+        status,
       },
     });
   } catch (error) {

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -17,22 +17,38 @@ const toObjectId = (value) => {
   return new mongoose.Types.ObjectId(value);
 };
 
+const sameId = (left, right) => left?.toString() === right?.toString();
+
 const canManageEvent = (event, user) =>
   user.role === ROLES.ADMIN ||
-  (user.role === ROLES.ORGANIZER_ADMIN &&
-    event.organizer.toString() === user.userId);
+  (user.role === ROLES.ORGANIZER_ADMIN && sameId(event.organizer, user.userId));
+
+const findEventBySafeId = async (safeEventId) => {
+  const events = await Event.find();
+  return events.find((event) => sameId(event._id, safeEventId));
+};
 
 const loadManagedEvent = async (eventId, user) => {
   const safeEventId =
     eventId instanceof mongoose.Types.ObjectId ? eventId : toObjectId(eventId);
   if (!safeEventId) return { status: 400, message: 'Invalid event id' };
 
-  const event = await Event.findById(safeEventId);
+  const event = await findEventBySafeId(safeEventId);
   if (!event) return { status: 404, message: 'Event not found' };
   if (!canManageEvent(event, user)) {
     return { status: 403, message: 'You cannot manage tasks for this event' };
   }
   return { event };
+};
+
+const findOrganizerBySafeId = async (safeUserId) => {
+  const organizers = await User.find({ role: ROLES.ORGANIZER });
+  return organizers.find((user) => sameId(user._id, safeUserId));
+};
+
+const findTaskBySafeId = async (safeTaskId) => {
+  const tasks = await Task.find();
+  return tasks.find((task) => sameId(task._id, safeTaskId));
 };
 
 const dateValue = (value) => new Date(value || 0).getTime();
@@ -64,9 +80,7 @@ const loadVisibleTasks = async (user) => {
     }
 
     const tasks = await query;
-    return tasks.filter(
-      (task) => task.assignedTo?._id?.toString() === organizerId.toString()
-    );
+    return tasks.filter((task) => sameId(task.assignedTo?._id, organizerId));
   }
 
   if (user.role === ROLES.ORGANIZER_ADMIN) {
@@ -78,9 +92,7 @@ const loadVisibleTasks = async (user) => {
     }
 
     const tasks = await query;
-    return tasks.filter(
-      (task) => task.event?.organizer?.toString() === organizerId.toString()
-    );
+    return tasks.filter((task) => sameId(task.event?.organizer, organizerId));
   }
 
   const error = new Error('Tasks are not available for this role');
@@ -133,8 +145,8 @@ exports.createTask = async (req, res) => {
         .json({ message: eventResult.message });
     }
 
-    const assignee = await User.findById(safeAssigneeId);
-    if (!assignee || assignee.role !== ROLES.ORGANIZER) {
+    const assignee = await findOrganizerBySafeId(safeAssigneeId);
+    if (!assignee) {
       return res
         .status(400)
         .json({ message: 'Tasks can only be assigned to organizers' });
@@ -201,11 +213,11 @@ const updateTask = async (req, res) => {
     const safeTaskId = toObjectId(req.params.id);
     if (!safeTaskId) return res.status(400).json({ message: 'Invalid task id' });
 
-    const task = await Task.findById(safeTaskId);
+    const task = await findTaskBySafeId(safeTaskId);
     if (!task) return res.status(404).json({ message: 'Task not found' });
 
     if (req.user.role === ROLES.ORGANIZER) {
-      if (task.assignedTo.toString() !== req.user.userId) {
+      if (!sameId(task.assignedTo, req.user.userId)) {
         return res
           .status(403)
           .json({ message: 'You can only update your assigned tasks' });
@@ -243,8 +255,8 @@ const updateTask = async (req, res) => {
         if (!safeAssigneeId) {
           return res.status(400).json({ message: 'Invalid assignee id' });
         }
-        const assignee = await User.findById(safeAssigneeId);
-        if (!assignee || assignee.role !== ROLES.ORGANIZER) {
+        const assignee = await findOrganizerBySafeId(safeAssigneeId);
+        if (!assignee) {
           return res
             .status(400)
             .json({ message: 'Tasks can only be assigned to organizers' });
@@ -272,7 +284,7 @@ exports.deleteTask = async (req, res) => {
     const safeTaskId = toObjectId(req.params.id);
     if (!safeTaskId) return res.status(400).json({ message: 'Invalid task id' });
 
-    const task = await Task.findById(safeTaskId);
+    const task = await findTaskBySafeId(safeTaskId);
     if (!task) return res.status(404).json({ message: 'Task not found' });
     const eventResult = await loadManagedEvent(task.event, req.user);
     if (!eventResult.event) {
@@ -283,7 +295,7 @@ exports.deleteTask = async (req, res) => {
 
     await task.deleteOne();
     eventResult.event.tasks = eventResult.event.tasks.filter(
-      (taskId) => taskId.toString() !== task._id.toString()
+      (taskId) => !sameId(taskId, task._id)
     );
     await eventResult.event.save();
     return res.json({ message: 'Task deleted successfully' });

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -12,6 +12,10 @@ const {
 
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
 const TASK_STATUSES = new Set(['Pending', 'In Progress', 'Completed']);
+const trustedServerFilterOptions = {
+  sanitizeFilter: false,
+  strictQuery: true,
+};
 
 const toObjectId = (value) => {
   if (typeof value !== 'string' || !OBJECT_ID_PATTERN.test(value)) return null;
@@ -28,9 +32,7 @@ const loadManagedEvent = async (eventId, user) => {
     eventId instanceof mongoose.Types.ObjectId ? eventId : toObjectId(eventId);
   if (!safeEventId) return { status: 400, message: 'Invalid event id' };
 
-  const event = await Event.findOne({
-    _id: { $eq: safeEventId },
-  }).setOptions({ sanitizeFilter: true, strictQuery: true });
+  const event = await Event.findById(safeEventId);
   if (!event) return { status: 404, message: 'Event not found' };
   if (!canManageEvent(event, user)) {
     return { status: 403, message: 'You cannot manage tasks for this event' };
@@ -163,12 +165,13 @@ exports.getAllTasks = async (req, res) => {
 
     const [tasks, total] = await Promise.all([
       Task.find(filter)
+        .setOptions(trustedServerFilterOptions)
         .populate('assignedTo', 'firstName lastName email role')
         .populate('event', 'name date isOnline')
         .sort(sort)
         .skip(skip)
         .limit(limit),
-      Task.countDocuments(filter),
+      Task.countDocuments(filter).setOptions(trustedServerFilterOptions),
     ]);
 
     return res.json({

--- a/backend/controllers/taskController.js
+++ b/backend/controllers/taskController.js
@@ -4,6 +4,11 @@ const Event = require('../models/Event');
 const User = require('../models/User');
 const TaskDTO = require('../dtos/TaskDTO');
 const { ROLES } = require('../constants/roles');
+const {
+  buildPaginationMeta,
+  getPaginationParams,
+  getSearchRegex,
+} = require('../utils/pagination');
 
 const OBJECT_ID_PATTERN = /^[0-9a-fA-F]{24}$/;
 const TASK_STATUSES = new Set(['Pending', 'In Progress', 'Completed']);
@@ -31,6 +36,67 @@ const loadManagedEvent = async (eventId, user) => {
     return { status: 403, message: 'You cannot manage tasks for this event' };
   }
   return { event };
+};
+
+const getTaskSort = (sort = 'newest') => {
+  const options = {
+    newest: { createdAt: -1 },
+    oldest: { createdAt: 1 },
+    status: { status: 1, createdAt: -1 },
+  };
+  return options[sort] || options.newest;
+};
+
+const buildRoleScopedTaskConditions = async (user) => {
+  if (user.role === ROLES.ORGANIZER) {
+    return [{ assignedTo: toObjectId(user.userId) }];
+  }
+
+  if (user.role === ROLES.ORGANIZER_ADMIN) {
+    const organizerId = toObjectId(user.userId);
+    if (!organizerId) {
+      const error = new Error('Invalid authenticated user');
+      error.status = 401;
+      throw error;
+    }
+
+    const managedEvents = await Event.find({ organizer: organizerId }).select('_id');
+    if (managedEvents.length === 0) return [{ _id: null }];
+
+    return [
+      {
+        $or: managedEvents.map((event) => ({ event: event._id })),
+      },
+    ];
+  }
+
+  if (user.role === ROLES.ADMIN) return [];
+
+  const error = new Error('Tasks are not available for this role');
+  error.status = 403;
+  throw error;
+};
+
+const buildTaskFilter = async (req) => {
+  const conditions = await buildRoleScopedTaskConditions(req.user);
+
+  if (req.query.status && req.query.status !== 'All') {
+    if (!TASK_STATUSES.has(req.query.status)) {
+      const error = new Error('Invalid task status');
+      error.status = 400;
+      throw error;
+    }
+    conditions.push({ status: req.query.status });
+  }
+
+  const searchRegex = getSearchRegex(req.query.search);
+  if (searchRegex) {
+    conditions.push({
+      $or: [{ title: searchRegex }, { description: searchRegex }],
+    });
+  }
+
+  return conditions.length > 0 ? { $and: conditions } : {};
 };
 
 exports.createTask = async (req, res) => {
@@ -88,29 +154,37 @@ exports.createTask = async (req, res) => {
 
 exports.getAllTasks = async (req, res) => {
   try {
-    let filter = {};
-    if (req.user.role === ROLES.ORGANIZER) {
-      filter = { assignedTo: toObjectId(req.user.userId) };
-    } else if (req.user.role === ROLES.ORGANIZER_ADMIN) {
-      const organizerId = toObjectId(req.user.userId);
-      if (!organizerId) {
-        return res.status(401).json({ message: 'Invalid authenticated user' });
-      }
-      const eventIds = await Event.find({ organizer: organizerId }).distinct('_id');
-      filter = { event: { $in: eventIds } };
-    } else if (req.user.role !== ROLES.ADMIN) {
-      return res
-        .status(403)
-        .json({ message: 'Tasks are not available for this role' });
-    }
+    const { page, limit, skip } = getPaginationParams(req.query, {
+      defaultLimit: 10,
+      maxLimit: 50,
+    });
+    const filter = await buildTaskFilter(req);
+    const sort = getTaskSort(req.query.sort);
 
-    const tasks = await Task.find(filter)
-      .populate('assignedTo', 'firstName lastName email role')
-      .sort({ createdAt: -1 });
-    return res.json({ tasks: tasks.map((task) => new TaskDTO(task)) });
+    const [tasks, total] = await Promise.all([
+      Task.find(filter)
+        .populate('assignedTo', 'firstName lastName email role')
+        .populate('event', 'name date isOnline')
+        .sort(sort)
+        .skip(skip)
+        .limit(limit),
+      Task.countDocuments(filter),
+    ]);
+
+    return res.json({
+      tasks: tasks.map((task) => new TaskDTO(task)),
+      pagination: buildPaginationMeta({ page, limit, total }),
+      filters: {
+        search: req.query.search || '',
+        sort: req.query.sort || 'newest',
+        status: req.query.status || 'All',
+      },
+    });
   } catch (error) {
     console.error('Task listing failed:', error.message);
-    return res.status(500).json({ message: 'Unable to fetch tasks' });
+    return res
+      .status(error.status || 500)
+      .json({ message: error.status ? error.message : 'Unable to fetch tasks' });
   }
 };
 

--- a/backend/dtos/EventDTO.js
+++ b/backend/dtos/EventDTO.js
@@ -1,18 +1,18 @@
-// dtos/EventDTO.js
 class EventDTO {
-    constructor(event) {
-      this.id = event._id;
-      this.name = event.name;
-      this.description = event.description;
-      this.date = event.date;
-      this.organizer = event.organizer; // Use UserDTO if organizer details are needed
-      this.participants = event.participants; // Can be UserDTOs if needed
-      this.tasks = event.tasks; // Include task details if needed
-      this.imagePath = event.imagePath || null;
-      this.createdAt = event.createdAt;
-      this.updatedAt = event.updatedAt;
-    }
+  constructor(event) {
+    this.id = event._id;
+    this.name = event.name;
+    this.description = event.description;
+    this.date = event.date;
+    this.organizer = event.organizer;
+    this.participants = event.participants;
+    this.tasks = event.tasks;
+    this.isOnline = Boolean(event.isOnline);
+    this.zoomLink = event.zoomLink || null;
+    this.imagePath = event.imagePath || null;
+    this.createdAt = event.createdAt;
+    this.updatedAt = event.updatedAt;
   }
-  
-  module.exports = EventDTO;
-  
+}
+
+module.exports = EventDTO;

--- a/backend/middlewares/rateLimiters.js
+++ b/backend/middlewares/rateLimiters.js
@@ -1,7 +1,7 @@
 const { rateLimit } = require('express-rate-limit');
 const { config } = require('../config/env');
 
-const createLimiter = (windowMs, limit, message) =>
+const createLimiter = ({ windowMs, limit, message }) =>
   rateLimit({
     windowMs,
     limit,
@@ -10,16 +10,40 @@ const createLimiter = (windowMs, limit, message) =>
     message: { message },
   });
 
-const apiLimiter = createLimiter(
-  config.rateLimitWindowMs,
-  config.rateLimitMax,
-  'Too many requests. Please try again later.'
-);
+const apiLimiter = createLimiter({
+  windowMs: config.rateLimitWindowMs,
+  limit: config.rateLimitMax,
+  message: 'Too many requests. Please try again later.',
+});
 
-const authLimiter = createLimiter(
-  config.authRateLimitWindowMs,
-  config.authRateLimitMax,
-  'Too many authentication attempts. Please try again later.'
-);
+const authLimiter = createLimiter({
+  windowMs: config.authRateLimitWindowMs,
+  limit: config.authRateLimitMax,
+  message: 'Too many authentication attempts. Please try again later.',
+});
 
-module.exports = { apiLimiter, authLimiter };
+const readLimiter = createLimiter({
+  windowMs: 60 * 1000,
+  limit: 240,
+  message: 'Too many read requests. Please slow down and try again shortly.',
+});
+
+const writeLimiter = createLimiter({
+  windowMs: 60 * 1000,
+  limit: 60,
+  message: 'Too many write requests. Please slow down and try again shortly.',
+});
+
+const uploadLimiter = createLimiter({
+  windowMs: 60 * 1000,
+  limit: 20,
+  message: 'Too many upload requests. Please slow down and try again shortly.',
+});
+
+module.exports = {
+  apiLimiter,
+  authLimiter,
+  readLimiter,
+  uploadLimiter,
+  writeLimiter,
+};

--- a/backend/routes/eventRoutes.js
+++ b/backend/routes/eventRoutes.js
@@ -12,18 +12,19 @@ const {
 const authMiddleware = require('../middlewares/authMiddleware');
 const authorize = require('../middlewares/authorize');
 const upload = require('../middlewares/uploadMiddleware');
+const { readLimiter, uploadLimiter, writeLimiter } = require('../middlewares/rateLimiters');
 const { ROLES } = require('../constants/roles');
 
 const router = express.Router();
 const managers = authorize(ROLES.ADMIN, ROLES.ORGANIZER_ADMIN);
 
-router.post('/', authMiddleware, managers, upload.single('image'), createEvent);
-router.get('/', authMiddleware, getEvents);
-router.put('/:id', authMiddleware, managers, upload.single('image'), updateEvent);
-router.patch('/:id', authMiddleware, managers, upload.single('image'), patchEvent);
-router.delete('/:id', authMiddleware, managers, deleteEvent);
-router.post('/:id/participate', authMiddleware, participateInEvent);
-router.post('/:id/unparticipate', authMiddleware, unparticipateEvent);
-router.get('/:id', authMiddleware, getEventById);
+router.post('/', authMiddleware, managers, uploadLimiter, upload.single('image'), createEvent);
+router.get('/', authMiddleware, readLimiter, getEvents);
+router.put('/:id', authMiddleware, managers, uploadLimiter, upload.single('image'), updateEvent);
+router.patch('/:id', authMiddleware, managers, uploadLimiter, upload.single('image'), patchEvent);
+router.delete('/:id', authMiddleware, managers, writeLimiter, deleteEvent);
+router.post('/:id/participate', authMiddleware, writeLimiter, participateInEvent);
+router.post('/:id/unparticipate', authMiddleware, writeLimiter, unparticipateEvent);
+router.get('/:id', authMiddleware, readLimiter, getEventById);
 
 module.exports = router;

--- a/backend/routes/taskRoutes.js
+++ b/backend/routes/taskRoutes.js
@@ -8,25 +8,28 @@ const {
 } = require('../controllers/taskController');
 const authMiddleware = require('../middlewares/authMiddleware');
 const authorize = require('../middlewares/authorize');
+const { readLimiter, writeLimiter } = require('../middlewares/rateLimiters');
 const { ROLES } = require('../constants/roles');
 
 const router = express.Router();
 const taskManagers = authorize(ROLES.ADMIN, ROLES.ORGANIZER_ADMIN);
 
-router.post('/', authMiddleware, taskManagers, createTask);
-router.get('/', authMiddleware, getAllTasks);
+router.post('/', authMiddleware, taskManagers, writeLimiter, createTask);
+router.get('/', authMiddleware, readLimiter, getAllTasks);
 router.put(
   '/:id',
   authMiddleware,
   authorize(ROLES.ADMIN, ROLES.ORGANIZER_ADMIN, ROLES.ORGANIZER),
+  writeLimiter,
   updateTask
 );
 router.patch(
   '/:id',
   authMiddleware,
   authorize(ROLES.ADMIN, ROLES.ORGANIZER_ADMIN, ROLES.ORGANIZER),
+  writeLimiter,
   patchTask
 );
-router.delete('/:id', authMiddleware, taskManagers, deleteTask);
+router.delete('/:id', authMiddleware, taskManagers, writeLimiter, deleteTask);
 
 module.exports = router;

--- a/backend/utils/pagination.js
+++ b/backend/utils/pagination.js
@@ -1,0 +1,50 @@
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 12;
+const MAX_LIMIT = 50;
+
+const toPositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const getPaginationParams = (query, options = {}) => {
+  const defaultLimit = options.defaultLimit || DEFAULT_LIMIT;
+  const maxLimit = options.maxLimit || MAX_LIMIT;
+  const page = toPositiveInteger(query.page, DEFAULT_PAGE);
+  const requestedLimit = toPositiveInteger(query.limit, defaultLimit);
+  const limit = Math.min(requestedLimit, maxLimit);
+
+  return {
+    page,
+    limit,
+    skip: (page - 1) * limit,
+  };
+};
+
+const buildPaginationMeta = ({ page, limit, total }) => {
+  const totalPages = Math.max(Math.ceil(total / limit), 1);
+
+  return {
+    page,
+    limit,
+    total,
+    totalPages,
+    hasNextPage: page < totalPages,
+    hasPreviousPage: page > 1,
+  };
+};
+
+const escapeRegex = (value) =>
+  String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const getSearchRegex = (value) => {
+  const search = String(value || '').trim();
+  if (!search) return null;
+  return new RegExp(escapeRegex(search), 'i');
+};
+
+module.exports = {
+  buildPaginationMeta,
+  getPaginationParams,
+  getSearchRegex,
+};

--- a/backend/utils/pagination.js
+++ b/backend/utils/pagination.js
@@ -1,22 +1,6 @@
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 12;
 const MAX_LIMIT = 50;
-const SPECIAL_REGEX_CHARS = new Set([
-  '\\',
-  '.',
-  '*',
-  '+',
-  '?',
-  '^',
-  '$',
-  '{',
-  '}',
-  '(',
-  ')',
-  '|',
-  '[',
-  ']',
-]);
 
 const toPositiveInteger = (value, fallback) => {
   const parsed = Number.parseInt(value, 10);
@@ -50,22 +34,7 @@ const buildPaginationMeta = ({ page, limit, total }) => {
   };
 };
 
-const escapeRegex = (value) =>
-  String(value)
-    .split('')
-    .map((character) =>
-      SPECIAL_REGEX_CHARS.has(character) ? `\\${character}` : character
-    )
-    .join('');
-
-const getSearchRegex = (value) => {
-  const search = String(value || '').trim();
-  if (!search) return null;
-  return new RegExp(escapeRegex(search), 'i');
-};
-
 module.exports = {
   buildPaginationMeta,
   getPaginationParams,
-  getSearchRegex,
 };

--- a/backend/utils/pagination.js
+++ b/backend/utils/pagination.js
@@ -1,6 +1,22 @@
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 12;
 const MAX_LIMIT = 50;
+const SPECIAL_REGEX_CHARS = new Set([
+  '\\',
+  '.',
+  '*',
+  '+',
+  '?',
+  '^',
+  '$',
+  '{',
+  '}',
+  '(',
+  ')',
+  '|',
+  '[',
+  ']',
+]);
 
 const toPositiveInteger = (value, fallback) => {
   const parsed = Number.parseInt(value, 10);
@@ -35,7 +51,12 @@ const buildPaginationMeta = ({ page, limit, total }) => {
 };
 
 const escapeRegex = (value) =>
-  String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  String(value)
+    .split('')
+    .map((character) =>
+      SPECIAL_REGEX_CHARS.has(character) ? `\\${character}` : character
+    )
+    .join('');
 
 const getSearchRegex = (value) => {
   const search = String(value || '').trim();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: 5000
+      TRUST_PROXY: "1"
       MONGO_URI: mongodb://mongo:27017/festivio
       JWT_SECRET: local-development-access-secret-change-me-123456789
       JWT_REFRESH_SECRET: local-development-refresh-secret-change-me-987654321

--- a/frontend/src/features/Event/EventPage.js
+++ b/frontend/src/features/Event/EventPage.js
@@ -8,6 +8,15 @@ import useAuthStore from '../../stores/authStore';
 const participantId = (participant) =>
   typeof participant === 'string' ? participant : participant?._id || participant?.id;
 
+const defaultPagination = {
+  page: 1,
+  limit: 9,
+  total: 0,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
 const EventPage = () => {
   const user = useAuthStore((state) => state.user);
   const [events, setEvents] = useState([]);
@@ -17,11 +26,26 @@ const EventPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
   const [confirmationModal, setConfirmationModal] = useState({ isOpen: false, eventId: null });
+  const [searchTerm, setSearchTerm] = useState('');
+  const [typeFilter, setTypeFilter] = useState('all');
+  const [timeframeFilter, setTimeframeFilter] = useState('upcoming');
+  const [sortOrder, setSortOrder] = useState('date_asc');
+  const [pagination, setPagination] = useState(defaultPagination);
   const navigate = useNavigate();
 
-  const fetchEvents = async () => {
+  const fetchEvents = async (nextPage = pagination.page) => {
+    setIsLoading(true);
     try {
-      const response = await axiosInstance.get('/api/events');
+      const params = new URLSearchParams({
+        page: String(nextPage),
+        limit: String(pagination.limit || 9),
+        sort: sortOrder,
+      });
+      if (searchTerm.trim()) params.set('search', searchTerm.trim());
+      if (typeFilter !== 'all') params.set('type', typeFilter);
+      if (timeframeFilter !== 'all') params.set('timeframe', timeframeFilter);
+
+      const response = await axiosInstance.get(`/api/events?${params.toString()}`);
       const nextEvents = (response.data.events || []).map((event) => ({
         ...event,
         isParticipating: (event.participants || []).some(
@@ -29,33 +53,32 @@ const EventPage = () => {
         ),
       }));
       setEvents(nextEvents);
+      setPagination(response.data.pagination || defaultPagination);
       setError('');
     } catch (_error) {
       setError('Unable to load events right now.');
+      setEvents([]);
+      setPagination(defaultPagination);
     } finally {
       setIsLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchEvents();
+    fetchEvents(1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id]);
+  }, [user?.id, searchTerm, typeFilter, timeframeFilter, sortOrder]);
 
   const handleParticipate = async (eventId) => {
     await axiosInstance.post(`/api/events/${eventId}/participate`);
-    setEvents((current) => current.map((event) =>
-      event.id === eventId ? { ...event, isParticipating: true } : event
-    ));
+    await fetchEvents(pagination.page);
   };
 
   const confirmUnparticipate = async () => {
     const eventId = confirmationModal.eventId;
     try {
       await axiosInstance.post(`/api/events/${eventId}/unparticipate`);
-      setEvents((current) => current.map((event) =>
-        event.id === eventId ? { ...event, isParticipating: false } : event
-      ));
+      await fetchEvents(pagination.page);
     } finally {
       setConfirmationModal({ isOpen: false, eventId: null });
     }
@@ -80,12 +103,12 @@ const EventPage = () => {
 
     await axiosInstance.post('/api/events', formData);
     closeModal();
-    await fetchEvents();
+    await fetchEvents(1);
   };
 
   const canCreateEvent = ['ROLE_ADMIN', 'ROLE_ORGANIZER_ADMIN'].includes(user?.role);
 
-  if (isLoading) return <main className="private-shell"><p>Loading events…</p></main>;
+  if (isLoading && events.length === 0) return <main className="private-shell"><p>Loading events…</p></main>;
 
   return (
     <main className="private-shell">
@@ -102,10 +125,35 @@ const EventPage = () => {
         )}
       </div>
 
+      <div className="task-toolbar" aria-label="Event filters">
+        <input
+          type="search"
+          placeholder="Search events"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
+        <select value={timeframeFilter} onChange={(event) => setTimeframeFilter(event.target.value)}>
+          <option value="upcoming">Upcoming</option>
+          <option value="past">Past</option>
+          <option value="all">All dates</option>
+        </select>
+        <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value)}>
+          <option value="all">All formats</option>
+          <option value="online">Online</option>
+          <option value="in_person">In person</option>
+        </select>
+        <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value)}>
+          <option value="date_asc">Soonest first</option>
+          <option value="date_desc">Latest date first</option>
+          <option value="newest">Newest created</option>
+          <option value="oldest">Oldest created</option>
+        </select>
+      </div>
+
       {error && <div className="inline-alert">{error}</div>}
 
-      <section className="event-grid">
-        {events.length === 0 && <div className="empty-state">No events yet.</div>}
+      <section className="event-grid" aria-busy={isLoading}>
+        {events.length === 0 && <div className="empty-state">No events match this view.</div>}
         {events.map((event) => (
           <article className="event-card" key={event.id}>
             <button className="event-card-main" onClick={() => navigate(`/events/${event.id}`)}>
@@ -132,6 +180,26 @@ const EventPage = () => {
           </article>
         ))}
       </section>
+
+      <div className="pagination-controls" aria-label="Events pagination">
+        <button
+          className="secondary-button"
+          disabled={!pagination.hasPreviousPage || isLoading}
+          onClick={() => fetchEvents(pagination.page - 1)}
+        >
+          Previous
+        </button>
+        <span>
+          Page {pagination.page} / {pagination.totalPages} · {pagination.total} events
+        </span>
+        <button
+          className="secondary-button"
+          disabled={!pagination.hasNextPage || isLoading}
+          onClick={() => fetchEvents(pagination.page + 1)}
+        >
+          Next
+        </button>
+      </div>
 
       {isModalOpen && (
         <div className="modal-overlay" role="presentation">

--- a/frontend/src/features/Task/TaskPage.js
+++ b/frontend/src/features/Task/TaskPage.js
@@ -2,6 +2,15 @@ import React, { useEffect, useState } from 'react';
 import axiosInstance from '../../api/axiosInstance';
 import './TaskPage.scss';
 
+const defaultPagination = {
+  page: 1,
+  limit: 10,
+  total: 0,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
 const assigneeName = (assignedTo) => {
   if (!assignedTo) return 'Unassigned';
   if (typeof assignedTo === 'string') return assignedTo;
@@ -14,50 +23,67 @@ const TaskPage = () => {
   const [error, setError] = useState('');
   const [statusFilter, setStatusFilter] = useState('All');
   const [searchTerm, setSearchTerm] = useState('');
+  const [sortOrder, setSortOrder] = useState('newest');
+  const [pagination, setPagination] = useState(defaultPagination);
 
-  const fetchTasks = async () => {
+  const fetchTasks = async (nextPage = pagination.page) => {
+    setLoading(true);
     try {
-      const response = await axiosInstance.get('/api/tasks');
+      const params = new URLSearchParams({
+        page: String(nextPage),
+        limit: String(pagination.limit || 10),
+        status: statusFilter,
+        sort: sortOrder,
+      });
+      if (searchTerm.trim()) params.set('search', searchTerm.trim());
+
+      const response = await axiosInstance.get(`/api/tasks?${params.toString()}`);
       setTasks(response.data.tasks || []);
+      setPagination(response.data.pagination || defaultPagination);
       setError('');
     } catch (_error) {
       setError('Unable to load tasks right now.');
       setTasks([]);
+      setPagination(defaultPagination);
     } finally {
       setLoading(false);
     }
   };
 
   useEffect(() => {
-    fetchTasks();
-  }, []);
+    fetchTasks(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter, searchTerm, sortOrder]);
 
   const handleStatusChange = async (taskId, newStatus) => {
     try {
       await axiosInstance.patch(`/api/tasks/${taskId}`, { status: newStatus });
-      await fetchTasks();
+      await fetchTasks(pagination.page);
     } catch (_error) {
       setError('Unable to update task status.');
     }
   };
 
-  const filteredTasks = tasks.filter((task) => {
-    const matchesStatus = statusFilter === 'All' || task.status === statusFilter;
-    const haystack = `${task.title || ''} ${task.description || ''}`.toLowerCase();
-    return matchesStatus && haystack.includes(searchTerm.toLowerCase());
-  });
-
-  if (loading) return <main className="private-shell"><p>Loading tasks…</p></main>;
+  if (loading && tasks.length === 0) return <main className="private-shell"><p>Loading tasks…</p></main>;
 
   return (
     <main className="private-shell task-page">
       <div className="page-heading"><div><p className="eyebrow">Execution</p><h1>Tasks</h1><p>Keep assigned work visible and move it forward.</p></div></div>
-      <div className="task-toolbar"><input type="search" placeholder="Search tasks" value={searchTerm} onChange={(event) => setSearchTerm(event.target.value)} /><select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}><option value="All">All statuses</option><option value="Pending">Pending</option><option value="In Progress">In progress</option><option value="Completed">Completed</option></select></div>
+      <div className="task-toolbar">
+        <input type="search" placeholder="Search tasks" value={searchTerm} onChange={(event) => setSearchTerm(event.target.value)} />
+        <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}><option value="All">All statuses</option><option value="Pending">Pending</option><option value="In Progress">In progress</option><option value="Completed">Completed</option></select>
+        <select value={sortOrder} onChange={(event) => setSortOrder(event.target.value)}><option value="newest">Newest first</option><option value="oldest">Oldest first</option><option value="status">Status</option></select>
+      </div>
       {error && <div className="inline-alert">{error}</div>}
-      <section className="task-list">
-        {filteredTasks.length === 0 && <div className="empty-state">No tasks match this view.</div>}
-        {filteredTasks.map((task) => <article key={task.id} className="task-card"><div><span className={`task-status-badge ${task.status.toLowerCase().replaceAll(' ', '-')}`}>{task.status}</span><h2>{task.title}</h2><p>{task.description || 'No description provided.'}</p><small>Assigned to {assigneeName(task.assignedTo)}</small></div><select aria-label={`Update status for ${task.title}`} value={task.status} onChange={(event) => handleStatusChange(task.id, event.target.value)}><option value="Pending">Pending</option><option value="In Progress">In progress</option><option value="Completed">Completed</option></select></article>)}
+      <section className="task-list" aria-busy={loading}>
+        {tasks.length === 0 && <div className="empty-state">No tasks match this view.</div>}
+        {tasks.map((task) => <article key={task.id} className="task-card"><div><span className={`task-status-badge ${task.status.toLowerCase().replaceAll(' ', '-')}`}>{task.status}</span><h2>{task.title}</h2><p>{task.description || 'No description provided.'}</p><small>Assigned to {assigneeName(task.assignedTo)}</small></div><select aria-label={`Update status for ${task.title}`} value={task.status} onChange={(event) => handleStatusChange(task.id, event.target.value)}><option value="Pending">Pending</option><option value="In Progress">In progress</option><option value="Completed">Completed</option></select></article>)}
       </section>
+      <div className="pagination-controls" aria-label="Tasks pagination">
+        <button className="secondary-button" disabled={!pagination.hasPreviousPage || loading} onClick={() => fetchTasks(pagination.page - 1)}>Previous</button>
+        <span>Page {pagination.page} / {pagination.totalPages} · {pagination.total} tasks</span>
+        <button className="secondary-button" disabled={!pagination.hasNextPage || loading} onClick={() => fetchTasks(pagination.page + 1)}>Next</button>
+      </div>
     </main>
   );
 };

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,6 +4,7 @@ import './styles/tokens.css';
 import './index.css';
 import './styles/public.css';
 import './styles/glass.css';
+import './styles/dataControls.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/frontend/src/styles/dataControls.css
+++ b/frontend/src/styles/dataControls.css
@@ -1,0 +1,68 @@
+.task-toolbar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.task-toolbar input,
+.task-toolbar select,
+.task-card select {
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: var(--app-surface);
+  color: var(--app-text);
+  outline: none;
+  transition: border-color var(--transition-fast), background var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.task-toolbar input:focus,
+.task-toolbar select:focus,
+.task-card select:focus {
+  border-color: rgba(138, 135, 255, .48);
+  box-shadow: 0 0 0 3px rgba(111, 108, 246, .1);
+  background: var(--app-surface-strong);
+}
+
+.task-toolbar input {
+  flex: 1 1 240px;
+}
+
+.task-toolbar select {
+  flex: 0 1 180px;
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 24px;
+  color: var(--app-muted);
+  font-size: .86rem;
+}
+
+.pagination-controls span {
+  min-width: 180px;
+  text-align: center;
+}
+
+.pagination-controls .secondary-button:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 650px) {
+  .task-toolbar,
+  .pagination-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .task-toolbar input,
+  .task-toolbar select,
+  .pagination-controls span {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Add shared backend pagination/search helpers with safe query parsing and escaped search regexes.
- Add paginated, searchable `/api/events` with filters for timeframe, format and sorting.
- Add paginated, searchable `/api/tasks` with status and sorting filters while preserving role-based access.
- Split backend rate limiting into read, write and upload limiters and apply them at route level.
- Update Events and Tasks pages to use server-driven search, filters and pagination metadata.
- Add shared frontend data control styles for toolbars and pagination controls.

## API examples
- `GET /api/events?page=1&limit=9&search=product&timeframe=upcoming&type=online&sort=date_asc`
- `GET /api/tasks?page=1&limit=10&search=briefing&status=Pending&sort=newest`

## Testing
Not run in the connector environment. Recommended local checks:
- `docker compose up -d --build`
- `docker compose exec backend npm test`
- `docker compose exec backend npm run seed:demo`
- Verify Events and Tasks pages with search/filter/pagination.